### PR TITLE
Fix Coal primitive loader for `GEOM_BOX`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,7 +83,10 @@ target_include_directories(
 )
 
 if(FFmpeg_FOUND)
-  message(STATUS "FFmpeg found. Building video module for candlewick_core.")
+  message(
+    STATUS
+    "FFmpeg found (version ${FFmpeg_VERSION}). Building video module for candlewick_core."
+  )
   target_compile_definitions(
     candlewick_core
     PUBLIC CANDLEWICK_WITH_FFMPEG_SUPPORT

--- a/src/candlewick/multibody/LoadCoalPrimitives.cpp
+++ b/src/candlewick/multibody/LoadCoalPrimitives.cpp
@@ -43,8 +43,7 @@ void getPlaneOrHalfspaceNormalOffset(const coal::CollisionGeometry &geometry,
   }
 }
 
-MeshData loadCoalPrimitive(const coal::CollisionGeometry &geometry,
-                           const Float4 &meshColor) {
+MeshData loadCoalPrimitive(const coal::CollisionGeometry &geometry) {
   using namespace coal;
   SDL_assert_always(geometry.getObjectType() == OT_GEOM);
   MeshData meshData{NoInit};
@@ -98,7 +97,8 @@ MeshData loadCoalPrimitive(const coal::CollisionGeometry &geometry,
     throw std::runtime_error("Unsupported geometry type.");
     break;
   }
-  meshData.material.baseColor = meshColor;
+  // apply appropriate transform for converting to Coal geometry's scaling
+  // parameters
   apply3DTransformInPlace(meshData, transform);
   return meshData;
 }

--- a/src/candlewick/multibody/LoadCoalPrimitives.cpp
+++ b/src/candlewick/multibody/LoadCoalPrimitives.cpp
@@ -53,7 +53,7 @@ MeshData loadCoalPrimitive(const coal::CollisionGeometry &geometry,
   switch (nodeType) {
   case GEOM_BOX: {
     auto &g = castGeom<Box>(geometry);
-    transform.scale(2 * g.halfSide.cast<float>());
+    transform.scale(g.halfSide.cast<float>());
     meshData = loadCubeSolid().toOwned();
     break;
   }

--- a/src/candlewick/multibody/LoadCoalPrimitives.h
+++ b/src/candlewick/multibody/LoadCoalPrimitives.h
@@ -11,8 +11,7 @@ namespace candlewick {
 ///
 /// See the documentation on the available primitives.
 /// \sa primitives1
-MeshData loadCoalPrimitive(const coal::CollisionGeometry &geometry,
-                           const Float4 &meshColor);
+MeshData loadCoalPrimitive(const coal::CollisionGeometry &geometry);
 
 MeshData loadCoalHeightField(const coal::CollisionGeometry &collGeom);
 

--- a/src/candlewick/multibody/LoadPinocchioGeometry.cpp
+++ b/src/candlewick/multibody/LoadPinocchioGeometry.cpp
@@ -27,7 +27,8 @@ void loadGeometryObject(const pin::GeometryObject &gobj,
     break;
   }
   case OT_GEOM: {
-    meshData.push_back(loadCoalPrimitive(collgom, meshColor));
+    MeshData &md = meshData.emplace_back(loadCoalPrimitive(collgom));
+    md.material.baseColor = meshColor;
     break;
   }
   case OT_HFIELD: {

--- a/src/candlewick/multibody/LoadPinocchioGeometry.cpp
+++ b/src/candlewick/multibody/LoadPinocchioGeometry.cpp
@@ -12,28 +12,28 @@ void loadGeometryObject(const pin::GeometryObject &gobj,
                         std::vector<MeshData> &meshData) {
   using namespace coal;
 
-  const coal::CollisionGeometry &collgom = *gobj.geometry.get();
+  const CollisionGeometry &collgom = *gobj.geometry.get();
   const OBJECT_TYPE objType = collgom.getObjectType();
 
   Float4 meshColor = gobj.meshColor.cast<float>();
   Float3 meshScale = gobj.meshScale.cast<float>();
+  const char *meshPath = gobj.meshPath.c_str();
+  bool overrideMaterial = gobj.overrideMaterial;
 
   Eigen::Affine3f T;
   T.setIdentity();
   T.scale(meshScale);
   switch (objType) {
   case OT_BVH: {
-    loadSceneMeshes(gobj.meshPath.c_str(), meshData);
+    loadSceneMeshes(meshPath, meshData);
     break;
   }
   case OT_GEOM: {
-    MeshData &md = meshData.emplace_back(loadCoalPrimitive(collgom));
-    md.material.baseColor = meshColor;
+    meshData.emplace_back(loadCoalPrimitive(collgom));
     break;
   }
   case OT_HFIELD: {
-    MeshData &md = meshData.emplace_back(loadCoalHeightField(collgom));
-    md.material.baseColor = meshColor;
+    meshData.emplace_back(loadCoalHeightField(collgom));
     break;
   }
   default:
@@ -42,6 +42,8 @@ void loadGeometryObject(const pin::GeometryObject &gobj,
   }
   for (auto &data : meshData) {
     apply3DTransformInPlace(data, T);
+    if (overrideMaterial)
+      data.material.baseColor = meshColor;
   }
 }
 


### PR DESCRIPTION
This fixes problems noticed by @stephane-caron :
- `candlewick::loadCoalPrimitive()` loads `GEOM_BOX` geometries twice as big as they're supposed to be.