### PR TITLE
[core] use C++20 `<source_location>` to replace error macros

### DIFF
--- a/src/candlewick/core/Mesh.cpp
+++ b/src/candlewick/core/Mesh.cpp
@@ -66,14 +66,14 @@ Mesh &Mesh::bindVertexBuffer(Uint32 slot, SDL_GPUBuffer *buffer) {
   for (std::size_t i = 0; i < numVertexBuffers(); i++) {
     if (m_layout.m_bufferDescs[i].slot == slot) {
       if (vertexBuffers[i]) {
-        throw InvalidArgument(
+        terminate_with_message(
             "Rebinding vertex buffer to already occupied slot.");
       }
       vertexBuffers[i] = buffer;
       return *this;
     }
   }
-  CANDLEWICK_TERMINATE("Binding slot not found!");
+  terminate_with_message("Binding slot not found!");
 }
 
 Mesh &Mesh::setIndexBuffer(SDL_GPUBuffer *buffer) {

--- a/src/candlewick/core/errors.cpp
+++ b/src/candlewick/core/errors.cpp
@@ -2,9 +2,11 @@
 #include <format>
 
 namespace candlewick {
-RAIIException::RAIIException(std::string_view msg)
+RAIIException::RAIIException(std::string_view msg,
+                             std::source_location location)
     : std::runtime_error(
-          std::format("RAIIException: SDL error \'{}\'", msg.data())) {}
+          std::format("{:s}({:d}) RAIIException: SDL error \'{}\'",
+                      location.file_name(), location.line(), msg.data())) {}
 
 namespace detail {
   std::string _error_message_impl(const char *fname, std::string_view _fmtstr,

--- a/src/candlewick/multibody/LoadCoalPrimitives.cpp
+++ b/src/candlewick/multibody/LoadCoalPrimitives.cpp
@@ -37,7 +37,7 @@ void getPlaneOrHalfspaceNormalOffset(const coal::CollisionGeometry &geometry,
     return;
   }
   default:
-    CANDLEWICK_UNREACHABLE_ASSERT(
+    unreachable_with_message(
         "This function should not be called with a "
         "non-Plane, non-Halfspace coal CollisionGeometry.");
   }

--- a/src/candlewick/multibody/LoadPinocchioGeometry.cpp
+++ b/src/candlewick/multibody/LoadPinocchioGeometry.cpp
@@ -36,7 +36,7 @@ void loadGeometryObject(const pin::GeometryObject &gobj,
     break;
   }
   default:
-    throw InvalidArgument("Unsupported object type.");
+    terminate_with_message("Unsupported object type.");
     break;
   }
   for (auto &data : meshData) {

--- a/src/candlewick/utils/LoadMesh.cpp
+++ b/src/candlewick/utils/LoadMesh.cpp
@@ -4,6 +4,7 @@
 #include "LoadMaterial.h"
 #include "../core/DefaultVertex.h"
 
+#include <source_location>
 #include <SDL3/SDL_log.h>
 #include <assimp/scene.h>
 #include <assimp/postprocess.h>
@@ -50,6 +51,13 @@ MeshData loadAiMesh(const aiMesh *inMesh, const aiMatrix4x4 transform) {
                   std::move(indexData)};
 }
 
+static void log_resource_failure(
+    const char *err_message,
+    std::source_location loc = std::source_location::current()) {
+  SDL_LogWarn(SDL_LOG_CATEGORY_APPLICATION, "%s: Failed to load resource [%s]",
+              loc.function_name(), err_message);
+}
+
 mesh_load_retc loadSceneMeshes(const char *path,
                                std::vector<MeshData> &meshData) {
 
@@ -66,8 +74,7 @@ mesh_load_retc loadSceneMeshes(const char *path,
   import.SetPropertyBool(AI_CONFIG_IMPORT_COLLADA_IGNORE_UP_DIRECTION, true);
   const aiScene *scene = import.ReadFile(path, pFlags);
   if (!scene) {
-    SDL_Log("%s: Warning: Failed to load resource. %s", __FUNCTION__,
-            import.GetErrorString());
+    log_resource_failure(import.GetErrorString());
     return mesh_load_retc::FAILED_TO_LOAD;
   }
 


### PR DESCRIPTION
+ remove CANDLEWICK_TERMINATE/CANDLEWICK_UNREACHABLE_ASSERT
+ LoadMesh.cpp : use source_location when logging scene load failure
+ RobotScene.cpp : simplify a message