### PR TITLE
Change main render passes' transparency blend state

### DIFF
--- a/src/candlewick/multibody/RobotScene.cpp
+++ b/src/candlewick/multibody/RobotScene.cpp
@@ -417,7 +417,19 @@ SDL_GPUGraphicsPipeline *RobotScene::createPipeline(
 
   SDL_GPUColorTargetDescription color_targets[2];
   SDL_zero(color_targets);
-  color_targets[0].format = render_target_format;
+  color_targets[0] = {
+      .format = render_target_format,
+      .blend_state =
+          {
+              .src_color_blendfactor = SDL_GPU_BLENDFACTOR_SRC_ALPHA,
+              .dst_color_blendfactor = SDL_GPU_BLENDFACTOR_ONE_MINUS_SRC_ALPHA,
+              .color_blend_op = SDL_GPU_BLENDOP_ADD,
+              .src_alpha_blendfactor = SDL_GPU_BLENDFACTOR_SRC_ALPHA,
+              .dst_alpha_blendfactor = SDL_GPU_BLENDFACTOR_ONE_MINUS_SRC_ALPHA,
+              .alpha_blend_op = SDL_GPU_BLENDOP_ADD,
+              .enable_blend = true,
+          },
+  };
   bool had_prepass =
       (type == PIPELINE_TRIANGLEMESH) && m_config.triangle_has_prepass;
   SDL_GPUCompareOp depth_compare_op = SDL_GPU_COMPAREOP_LESS_OR_EQUAL;


### PR DESCRIPTION
This fixes one of the render bugs noticed by @stephane-caron, because upkie has a transparent main body.

![image](https://github.com/user-attachments/assets/3c349c9f-c2e8-4808-a7de-1f78d1044c4c)
