### PR TITLE
[python] Fix `Visualizer` getters for Pinocchio 3.5.0

### DIFF
--- a/bindings/python/src/expose-visualizer.cpp
+++ b/bindings/python/src/expose-visualizer.cpp
@@ -4,6 +4,7 @@
 #include "candlewick/multibody/Visualizer.h"
 #include <pinocchio/bindings/python/visualizers/visualizer-visitor.hpp>
 
+#include <pinocchio/config.hpp>
 #include <pinocchio/multibody/model.hpp>
 #include <pinocchio/multibody/geometry.hpp>
 
@@ -14,11 +15,29 @@ void exposeVisualizer() {
   bp::class_<Visualizer::Config>("VisualizerConfig", bp::init<>())
       .def_readwrite("width", &Visualizer::Config::width)
       .def_readwrite("height", &Visualizer::Config::height);
-  bp::class_<Visualizer, boost::noncopyable>("Visualizer", bp::no_init)
-      .def(bp::init<Visualizer::Config, const pin::Model &,
-                    const pin::GeometryModel &>(
-          ("self"_a, "config", "model", "geomModel")))
-      .def(pinocchio::python::VisualizerPythonVisitor<Visualizer>{})
-      .def_readonly("renderer", &Visualizer::renderer)
-      .add_property("shouldExit", &Visualizer::shouldExit);
+
+  auto cl =
+      bp::class_<Visualizer, boost::noncopyable>("Visualizer", bp::no_init)
+          .def(bp::init<Visualizer::Config, const pin::Model &,
+                        const pin::GeometryModel &>(
+              ("self"_a, "config", "model", "geomModel")))
+          .def(pinocchio::python::VisualizerPythonVisitor<Visualizer>{})
+          .def_readonly("renderer", &Visualizer::renderer)
+          .add_property("shouldExit", &Visualizer::shouldExit);
+
+// fix for Pinocchio 3.5.0
+#if PINOCCHIO_VERSION_AT_MOST(3, 5, 0)
+#define DEF_PROP_PROXY(name)                                                   \
+  add_property(#name, bp::make_function(                                       \
+                          +[](Visualizer &v) -> auto & { return v.name(); },   \
+                          bp::return_internal_reference<>()))
+  cl //
+      .DEF_PROP_PROXY(model)
+      .DEF_PROP_PROXY(visualModel)
+      .DEF_PROP_PROXY(collisionModel)
+      .DEF_PROP_PROXY(data)
+      .DEF_PROP_PROXY(visualData)
+      .DEF_PROP_PROXY(collisionData);
+#undef DEF_PROP_PROXY
+#endif
 }

--- a/examples/python/ur10_loop.py
+++ b/examples/python/ur10_loop.py
@@ -29,6 +29,7 @@ dt = 0.02
 M = pin.SE3.Identity()
 ee_name = "ee_link"
 ee_id = model.getFrameId(ee_name)
+print(viz.model)
 
 for i in range(1000):
     alpha = np.sin(t)


### PR DESCRIPTION

This PR adds a fix for the Pinocchio model and data getters on Pinocchio 3.5.0, the version prior to
stack-of-tasks/pinocchio/pull/2647.

- **examples/python : add print test for viz.model**
- **expose-visualizer.cpp : add fix for visualizer getters on Pinocchio 3.5.0**
