### PR TITLE
Add support for Coal `GEOM_ELLIPSOID` and `GEOM_CONVEX` geometries, add `candlewick::strided_view<T>` type

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -1,0 +1,14 @@
+name: Check-changelog
+on:
+  pull_request:
+    types: [assigned, opened, synchronize, reopened, labeled, unlabeled]
+    branches:
+      - main
+jobs:
+  check-changelog:
+    name: Check changelog action
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tarides/changelog-check-action@v3
+        with:
+          changelog: CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+This is the first release to use a changelog.
+
+### Removed
+
+- Remove `MeshData loadCoalHeightField(const coal::CollisionGeometry &collGeom)`
+
+### Added
+
+- Add template class `strided_view<T>` for non-contiguous evenly-strided data
+- Extend support for coal `CollisionGeometry` objects
+  - Add support for `coal::GEOM_ELLIPSOID`
+  - Add support for `coal::GEOM_CONVEX`
+  - Add loader `loadCoalConvex()`
+
+### Changed
+
+- Change signature of `loadCoalPrimitive()` to take `coal::ShapeBase`
+- Change signature of `MeshData::getAttribute()` template member function to use strided view
+
+
+
+[Unreleased]: https://github.com/Simple-Robotics/candlewick/compare/v0.0.5...HEAD

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,12 +95,16 @@ message(STATUS "Shader install dir: ${CANDLEWICK_SHADER_INSTALL_DIR}")
 
 add_subdirectory(external)
 add_subdirectory(src)
+
 if(BUILD_EXAMPLES)
   add_subdirectory(examples)
 endif()
+
 if(BUILD_TESTING)
+  enable_testing()
   add_subdirectory(tests)
 endif()
+
 if(BUILD_PYTHON_BINDINGS)
   add_subdirectory(bindings/python)
   # WIP nanobind bindings

--- a/src/candlewick/multibody/LoadCoalGeometries.cpp
+++ b/src/candlewick/multibody/LoadCoalGeometries.cpp
@@ -16,29 +16,19 @@ namespace candlewick {
 
 constexpr float kPlaneScale = 10.f;
 
-// helper
-template <typename T>
-decltype(auto) castGeom(const coal::CollisionGeometry &geometry) {
-#ifndef DEBUG
-  return static_cast<const T &>(geometry);
-#else
-  return dynamic_cast<const T &>(geometry);
-#endif
-}
-
 static void
 getPlaneOrHalfspaceNormalOffset(const coal::CollisionGeometry &geometry,
                                 Float3 &n, float &d) {
   using namespace coal;
   switch (geometry.getNodeType()) {
   case GEOM_PLANE: {
-    auto &g = castGeom<Plane>(geometry);
+    auto &g = castCoalGeom<Plane>(geometry);
     n = g.n.cast<float>();
     d = float(g.d);
     return;
   }
   case GEOM_HALFSPACE: {
-    auto &g = castGeom<Halfspace>(geometry);
+    auto &g = castCoalGeom<Halfspace>(geometry);
     n = g.n.cast<float>();
     d = float(g.d);
     return;
@@ -50,7 +40,7 @@ getPlaneOrHalfspaceNormalOffset(const coal::CollisionGeometry &geometry,
   }
 }
 
-static MeshData loadCoalConvex(const coal::ConvexBase &geom_) {
+MeshData loadCoalConvex(const coal::ConvexBase &geom_) {
   std::vector<DefaultVertex> vertexData;
   std::vector<MeshData::IndexType> indexData;
 
@@ -97,13 +87,13 @@ MeshData loadCoalPrimitive(const coal::CollisionGeometry &geometry) {
   const NODE_TYPE nodeType = geometry.getNodeType();
   switch (nodeType) {
   case GEOM_BOX: {
-    auto &g = castGeom<Box>(geometry);
+    auto &g = castCoalGeom<Box>(geometry);
     transform.scale(g.halfSide.cast<float>());
     meshData = loadCubeSolid().toOwned();
     break;
   }
   case GEOM_SPHERE: {
-    auto &g = castGeom<Sphere>(geometry);
+    auto &g = castCoalGeom<Sphere>(geometry);
     // sphere loader doesn't have a radius argument, so apply scaling
     transform.scale(float(g.radius));
     meshData = loadUvSphereSolid(8u, 16u);
@@ -115,32 +105,32 @@ MeshData loadCoalPrimitive(const coal::CollisionGeometry &geometry) {
     break;
   }
   case GEOM_CONVEX: {
-    auto &g = castGeom<ConvexBase>(geometry);
+    auto &g = castCoalGeom<ConvexBase>(geometry);
     meshData = loadCoalConvex(g);
     terminate_with_message("Geometry type \'GEOM_CONVEX\' not supported.");
     break;
   }
   case GEOM_ELLIPSOID: {
-    auto &g = castGeom<Ellipsoid>(geometry);
+    auto &g = castCoalGeom<Ellipsoid>(geometry);
     transform.scale(g.radii.cast<float>());
     meshData = loadUvSphereSolid(8u, 16u);
     break;
   }
   case GEOM_CAPSULE: {
-    auto &g = castGeom<Capsule>(geometry);
+    auto &g = castCoalGeom<Capsule>(geometry);
     const float length = static_cast<float>(2 * g.halfLength);
     transform.scale(float(g.radius));
     meshData = loadCapsuleSolid(6u, 16u, length);
     break;
   }
   case GEOM_CONE: {
-    auto &g = castGeom<Cone>(geometry);
+    auto &g = castCoalGeom<Cone>(geometry);
     float length = 2 * float(g.halfLength);
     meshData = loadConeSolid(16u, float(g.radius), length);
     break;
   }
   case GEOM_CYLINDER: {
-    auto &g = castGeom<Cylinder>(geometry);
+    auto &g = castCoalGeom<Cylinder>(geometry);
     float height = 2.f * float(g.halfLength);
     meshData = loadCylinderSolid(6u, 16u, float(g.radius), height);
     break;

--- a/src/candlewick/multibody/LoadCoalGeometries.cpp
+++ b/src/candlewick/multibody/LoadCoalGeometries.cpp
@@ -78,7 +78,7 @@ MeshData loadCoalConvex(const coal::ConvexBase &geom_) {
   return MeshData{SDL_GPU_PRIMITIVETYPE_TRIANGLELIST, std::move(vertexData)};
 }
 
-MeshData loadCoalPrimitive(const coal::CollisionGeometry &geometry) {
+MeshData loadCoalPrimitive(const coal::ShapeBase &geometry) {
   using namespace coal;
   CDW_ASSERT(geometry.getObjectType() == OT_GEOM,
              "CollisionGeometry object type must be OT_GEOM !");

--- a/src/candlewick/multibody/LoadCoalGeometries.h
+++ b/src/candlewick/multibody/LoadCoalGeometries.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "../utils/Utils.h"
+
+#include <coal/fwd.hh>
+
+namespace coal {
+template <typename BV> class HeightField;
+class OBBRSS;
+} // namespace coal
+
+namespace candlewick {
+
+/// \brief Load primitive given a coal::CollisionGeometry.
+/// The geometry must be of object type coal::OT_GEOM.
+///
+/// See the documentation on the available primitives.
+/// \sa primitives1
+MeshData loadCoalPrimitive(const coal::CollisionGeometry &geometry);
+
+MeshData loadCoalHeightField(const coal::HeightField<coal::AABB> &collGeom);
+
+MeshData loadCoalHeightField(const coal::HeightField<coal::OBBRSS> &collGeom);
+
+} // namespace candlewick

--- a/src/candlewick/multibody/LoadCoalGeometries.h
+++ b/src/candlewick/multibody/LoadCoalGeometries.h
@@ -7,9 +7,20 @@
 namespace coal {
 template <typename BV> class HeightField;
 class OBBRSS;
+class ShapeBase;
+class ConvexBase;
 } // namespace coal
 
 namespace candlewick {
+
+template <typename T>
+decltype(auto) castCoalGeom(const coal::CollisionGeometry &geometry) {
+#ifndef DEBUG
+  return static_cast<const T &>(geometry);
+#else
+  return dynamic_cast<const T &>(geometry);
+#endif
+}
 
 /// \brief Load primitive given a coal::CollisionGeometry.
 /// The geometry must be of object type coal::OT_GEOM.
@@ -17,6 +28,8 @@ namespace candlewick {
 /// See the documentation on the available primitives.
 /// \sa primitives1
 MeshData loadCoalPrimitive(const coal::CollisionGeometry &geometry);
+
+MeshData loadCoalConvex(const coal::ConvexBase &geom);
 
 MeshData loadCoalHeightField(const coal::HeightField<coal::AABB> &collGeom);
 

--- a/src/candlewick/multibody/LoadCoalGeometries.h
+++ b/src/candlewick/multibody/LoadCoalGeometries.h
@@ -23,11 +23,10 @@ decltype(auto) castCoalGeom(const coal::CollisionGeometry &geometry) {
 }
 
 /// \brief Load primitive given a coal::CollisionGeometry.
-/// The geometry must be of object type coal::OT_GEOM.
 ///
 /// See the documentation on the available primitives.
 /// \sa primitives1
-MeshData loadCoalPrimitive(const coal::CollisionGeometry &geometry);
+MeshData loadCoalPrimitive(const coal::ShapeBase &geometry);
 
 MeshData loadCoalConvex(const coal::ConvexBase &geom);
 

--- a/src/candlewick/multibody/LoadCoalPrimitives.cpp
+++ b/src/candlewick/multibody/LoadCoalPrimitives.cpp
@@ -17,7 +17,11 @@ constexpr float kPlaneScale = 10.f;
 // helper
 template <typename T>
 decltype(auto) castGeom(const coal::CollisionGeometry &geometry) {
+#ifndef DEBUG
   return static_cast<const T &>(geometry);
+#else
+  return dynamic_cast<const T &>(geometry);
+#endif
 }
 
 static void

--- a/src/candlewick/multibody/LoadCoalPrimitives.cpp
+++ b/src/candlewick/multibody/LoadCoalPrimitives.cpp
@@ -63,6 +63,12 @@ MeshData loadCoalPrimitive(const coal::CollisionGeometry &geometry) {
     meshData = loadUvSphereSolid(8u, 16u);
     break;
   }
+  case GEOM_ELLIPSOID: {
+    auto &g = castGeom<Ellipsoid>(geometry);
+    transform.scale(g.radii.cast<float>());
+    meshData = loadUvSphereSolid(8u, 16u);
+    break;
+  }
   case GEOM_CAPSULE: {
     auto &g = castGeom<Capsule>(geometry);
     const float length = static_cast<float>(2 * g.halfLength);

--- a/src/candlewick/multibody/LoadCoalPrimitives.cpp
+++ b/src/candlewick/multibody/LoadCoalPrimitives.cpp
@@ -20,8 +20,9 @@ decltype(auto) castGeom(const coal::CollisionGeometry &geometry) {
   return static_cast<const T &>(geometry);
 }
 
-void getPlaneOrHalfspaceNormalOffset(const coal::CollisionGeometry &geometry,
-                                     Float3 &n, float &d) {
+static void
+getPlaneOrHalfspaceNormalOffset(const coal::CollisionGeometry &geometry,
+                                Float3 &n, float &d) {
   using namespace coal;
   switch (geometry.getNodeType()) {
   case GEOM_PLANE: {
@@ -100,7 +101,7 @@ MeshData loadCoalPrimitive(const coal::CollisionGeometry &geometry) {
     break;
   }
   default:
-    throw std::runtime_error("Unsupported geometry type.");
+    terminate_with_message("Unsupported geometry type.");
     break;
   }
   // apply appropriate transform for converting to Coal geometry's scaling
@@ -135,7 +136,7 @@ MeshData loadCoalHeightField(const coal::CollisionGeometry &collGeom) {
     return detail::load_coal_heightfield_impl(geom);
   }
   default:
-    throw std::runtime_error("Unsupported nodeType.");
+    terminate_with_message("Unsupported nodeType.");
   }
 }
 } // namespace candlewick

--- a/src/candlewick/multibody/LoadCoalPrimitives.h
+++ b/src/candlewick/multibody/LoadCoalPrimitives.h
@@ -1,18 +1,8 @@
 #pragma once
 
-#include "../utils/Utils.h"
-#include "../core/math_types.h"
+#include "candlewick/deprecated.h"
+#include "candlewick/multibody/LoadCoalGeometries.h"
 
-#include <coal/fwd.hh>
-
-namespace candlewick {
-
-/// \brief Load primitive given a coal::CollisionGeometry.
-///
-/// See the documentation on the available primitives.
-/// \sa primitives1
-MeshData loadCoalPrimitive(const coal::CollisionGeometry &geometry);
-
-MeshData loadCoalHeightField(const coal::CollisionGeometry &collGeom);
-
-} // namespace candlewick
+CANDLEWICK_DEPRECATED_HEADER(
+    "This header is deprecated. Use "
+    "<candlewick/multibody/LoadCoalGeometries.h> instead.")

--- a/src/candlewick/multibody/LoadPinocchioGeometry.cpp
+++ b/src/candlewick/multibody/LoadPinocchioGeometry.cpp
@@ -18,7 +18,6 @@ void loadGeometryObject(const pin::GeometryObject &gobj,
   Float4 meshColor = gobj.meshColor.cast<float>();
   Float3 meshScale = gobj.meshScale.cast<float>();
   const char *meshPath = gobj.meshPath.c_str();
-  bool overrideMaterial = gobj.overrideMaterial;
 
   Eigen::Affine3f T;
   T.setIdentity();
@@ -42,7 +41,7 @@ void loadGeometryObject(const pin::GeometryObject &gobj,
   }
   for (auto &data : meshData) {
     apply3DTransformInPlace(data, T);
-    if (overrideMaterial)
+    if (gobj.overrideMaterial)
       data.material.baseColor = meshColor;
   }
 }

--- a/src/candlewick/multibody/LoadPinocchioGeometry.cpp
+++ b/src/candlewick/multibody/LoadPinocchioGeometry.cpp
@@ -1,5 +1,5 @@
 #include "LoadPinocchioGeometry.h"
-#include "LoadCoalPrimitives.h"
+#include "LoadCoalGeometries.h"
 #include "../core/errors.h"
 #include "../utils/LoadMesh.h"
 #include "../utils/MeshTransforms.h"

--- a/src/candlewick/utils/LoadMaterial.cpp
+++ b/src/candlewick/utils/LoadMaterial.cpp
@@ -1,4 +1,5 @@
 #include "LoadMaterial.h"
+#include "candlewick/core/errors.h"
 
 #include <magic_enum/magic_enum.hpp>
 
@@ -91,6 +92,6 @@ PbrMaterial loadFromAssimpMaterial(aiMaterial *material) {
 
   std::string msg = "Failed to load material: return code ";
   msg += magic_enum::enum_name(retc);
-  throw std::runtime_error(msg);
+  terminate_with_message(msg);
 }
 } // namespace candlewick

--- a/src/candlewick/utils/MeshData.cpp
+++ b/src/candlewick/utils/MeshData.cpp
@@ -12,11 +12,10 @@ MeshData::MeshData(NoInitT) {}
 MeshData::MeshData(SDL_GPUPrimitiveType primitiveType, const MeshLayout &layout,
                    std::vector<char> vertexData,
                    std::vector<IndexType> indexData)
-    : m_vertexData(std::move(vertexData)), primitiveType(primitiveType),
-      layout(layout), indexData(std::move(indexData)) {
-  m_vertexSize = this->layout.vertexSize();
-  m_numVertices = static_cast<Uint32>(m_vertexData.size()) / m_vertexSize;
-}
+    : m_vertexData(std::move(vertexData)),
+      m_numVertices(Uint32(vertexBytes()) / layout.vertexSize()),
+      primitiveType(primitiveType), layout(layout),
+      indexData(std::move(indexData)) {}
 
 Mesh createMesh(const Device &device, const MeshData &meshData, bool upload) {
   auto &layout = meshData.layout;

--- a/src/candlewick/utils/MeshData.h
+++ b/src/candlewick/utils/MeshData.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Utils.h"
+#include "../core/errors.h"
 #include "../core/MeshLayout.h"
 #include "../core/MaterialUniform.h"
 #include "../core/Tags.h"
@@ -82,12 +83,11 @@ public:
 
   template <typename T>
   [[nodiscard]] T &getAttribute(const Uint64 vertexId, VertexAttrib loc) {
-    auto attr = layout.getAttribute(loc);
-    if (!attr) {
-      throw std::runtime_error("Vertex attribute " +
-                               std::to_string(Uint16(loc)) + "not found.");
+    if (auto attr = layout.getAttribute(loc)) {
+      return this->getAttribute<T>(vertexId, *attr);
     }
-    return this->getAttribute<T>(vertexId, *attr);
+    terminate_with_message(
+        std::format("Vertex attribute %d not found.", Uint16(loc)));
   }
 
   std::span<const char> vertexData() const { return m_vertexData; }

--- a/src/candlewick/utils/MeshTransforms.cpp
+++ b/src/candlewick/utils/MeshTransforms.cpp
@@ -11,23 +11,26 @@ void apply3DTransformInPlace(MeshData &meshData, const Eigen::Affine3f &tr) {
   const MeshLayout &layout = meshData.layout;
 
   if (auto posAttr = layout.getAttribute(VertexAttrib::Position)) {
+    auto view = meshData.getAttribute<GpuVec3>(*posAttr);
     for (Uint64 i = 0; i < meshData.numVertices(); i++) {
-      Float3 &pos = meshData.getAttribute<Float3>(i, *posAttr);
+      GpuVec3 &pos = view[i];
       pos = tr * pos;
     }
   }
 
   Eigen::Matrix3f normalMatrix = tr.linear().inverse().transpose();
   if (auto normAttr = layout.getAttribute(VertexAttrib::Normal)) {
+    auto view = meshData.getAttribute<GpuVec3>(*normAttr);
     for (Uint64 i = 0; i < meshData.numVertices(); i++) {
-      Float3 &normal = meshData.getAttribute<Float3>(i, *normAttr);
+      GpuVec3 &normal = view[i];
       normal.applyOnTheLeft(normalMatrix);
     }
   }
 
   if (auto tangAttr = layout.getAttribute(VertexAttrib::Tangent)) {
+    auto view = meshData.getAttribute<GpuVec3>(*tangAttr);
     for (Uint64 i = 0; i < meshData.numVertices(); i++) {
-      Float3 &tang = meshData.getAttribute<Float3>(i, *tangAttr);
+      GpuVec3 &tang = view[i];
       tang.applyOnTheLeft(normalMatrix);
     }
   }

--- a/src/candlewick/utils/MeshTransforms.h
+++ b/src/candlewick/utils/MeshTransforms.h
@@ -11,6 +11,8 @@ namespace candlewick {
 /// transforming its vertices.
 void apply3DTransformInPlace(MeshData &meshData, const Eigen::Affine3f &tr);
 
+/// \brief Generate indices for a triangle strip geometry, given the vertex
+/// count.
 void triangleStripGenerateIndices(Uint32 vertexCount,
                                   std::vector<Uint32> &indices);
 

--- a/src/candlewick/utils/StridedView.h
+++ b/src/candlewick/utils/StridedView.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <iterator>
+#include <span>
+#include <type_traits>
+#include <stdexcept>
+
+namespace candlewick {
+
+/// \brief A strided view to data, allowing for type-erased data.
+///
+/// The stride is specified in terms of bytes instead of \c T.
+/// \tparam T Stored data type.
+template <typename T> class strided_view {
+  [[nodiscard]] char *erased_ptr() const {
+    return reinterpret_cast<char *>(m_data);
+  }
+
+public:
+  using element_type = T;
+  using value_type = std::remove_cv_t<T>;
+  using size_type = size_t;
+  using pointer = T *;
+  using const_pointer = const T *;
+  using reference = element_type &;
+  using const_reference = const element_type &;
+
+  constexpr strided_view() noexcept : m_data(nullptr), m_size(0), m_stride(0) {}
+
+  /// \brief Build a view from an iterator given the size and stride.
+  template <std::random_access_iterator It>
+  strided_view(It first, size_type count, size_type stride_bytes) noexcept
+      : m_data(std::to_address(first)), m_size(count), m_stride(stride_bytes) {}
+
+  /// \brief Build a view from an iterator and given element count.
+  /// The stride is assumed to be \c sizeof(T), i.e. the data is contiguous.
+  template <std::random_access_iterator It>
+  strided_view(It first, size_type count) noexcept
+      : strided_view(first, count, sizeof(T)) {}
+
+  template <size_t extent>
+  strided_view(std::span<element_type, extent> other,
+               size_type stride_bytes) noexcept
+      : m_data(other.data()), m_size(other.size()), m_stride(stride_bytes) {}
+
+  template <size_t extent>
+  strided_view(std::span<element_type, extent> other) noexcept
+      : strided_view(other, sizeof(element_type)) {}
+
+  template <size_t array_extent>
+  strided_view(std::type_identity_t<element_type> (&arr)[array_extent],
+               size_t stride_bytes = sizeof(element_type)) noexcept
+      : strided_view(static_cast<pointer>(arr), array_extent, stride_bytes) {}
+
+  ~strided_view() noexcept = default;
+
+  strided_view &operator=(const strided_view &) noexcept = default;
+
+  /// \brief Size (number of elements) of the view.
+  [[nodiscard]] size_type size() const noexcept { return m_size; }
+
+  /// \brief Stride in bytes between two elements of the view.
+  [[nodiscard]] size_type stride_bytes() const noexcept { return m_stride; }
+
+  [[nodiscard]] size_t max_index() const {
+    size_t stride_in_T = m_stride / sizeof(element_type);
+    size_t q = m_size / stride_in_T;
+    size_t m = m_size % stride_in_T;
+    return q + ((m > 0) ? 1 : 0);
+  }
+
+  [[nodiscard]] bool empty() const noexcept { return size() == 0; }
+
+  [[nodiscard]] reference front() const noexcept { return *m_data; }
+
+  [[nodiscard]] reference back() const noexcept {
+    return *reinterpret_cast<pointer>(erased_ptr() + m_stride * (m_size - 1));
+  }
+
+  [[nodiscard]] reference operator[](size_type idx) const noexcept {
+    return *reinterpret_cast<pointer>(erased_ptr() + m_stride * idx);
+  }
+
+  [[nodiscard]] reference at(size_type idx) const {
+    if (idx >= max_index())
+      throw std::out_of_range("Access out of range.");
+    return this->operator[](idx);
+  }
+
+  [[nodiscard]] pointer data() const noexcept { return m_data; }
+
+private:
+  pointer m_data;     //< Pointer to the first element in the view
+  size_type m_size;   //<
+  size_type m_stride; //< Stride in  bytes
+};
+
+template <typename T> strided_view(T *first, size_t, size_t) -> strided_view<T>;
+
+template <typename T, size_t extent>
+strided_view(std::span<T, extent>, size_t) -> strided_view<T>;
+
+template <typename T, size_t arr_extent>
+strided_view(T (&)[arr_extent]) -> strided_view<T>;
+
+} // namespace candlewick

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,3 +11,4 @@ function(add_candlewick_test filename)
 endfunction()
 
 add_candlewick_test(TestMeshData.cpp)
+add_candlewick_test(TestStrided.cpp)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,13 +1,11 @@
-enable_testing()
 find_package(GTest REQUIRED)
 
 function(add_candlewick_test filename)
   cmake_path(GET filename STEM name)
   add_executable(${name} ${filename})
   target_link_libraries(${name} PRIVATE candlewick_core GTest::gtest_main)
-  foreach(arg ${ARGN})
-    target_link_libraries(${name} PRIVATE ${arg})
-  endforeach()
+  target_link_libraries(${name} PRIVATE ${ARGN})
+  add_test(NAME ${name} COMMAND ${name})
 endfunction()
 
 add_candlewick_test(TestMeshData.cpp)

--- a/tests/TestMeshData.cpp
+++ b/tests/TestMeshData.cpp
@@ -54,14 +54,14 @@ GTEST_TEST(TestErasedBlob, default_vertex) {
   std::span<const DefaultVertex> view = data.viewAs<DefaultVertex>();
   EXPECT_EQ(view.size(), size);
 
+  strided_view pos_view = data.getAttribute<Float3>(VertexAttrib::Position);
+  strided_view nor_view = data.getAttribute<Float3>(VertexAttrib::Normal);
+  strided_view col_view = data.getAttribute<Float4>(VertexAttrib::Color0);
   for (Uint64 i = 0; i < size; i++) {
     EXPECT_TRUE(view[i] == vertexData[i]);
-    EXPECT_TRUE(vertexData[i].pos ==
-                data.getAttribute<Float3>(i, VertexAttrib::Position));
-    EXPECT_TRUE(vertexData[i].normal ==
-                data.getAttribute<Float3>(i, VertexAttrib::Normal));
-    EXPECT_TRUE(vertexData[i].color ==
-                data.getAttribute<Float4>(i, VertexAttrib::Color0));
+    EXPECT_TRUE(vertexData[i].pos == pos_view[i]);
+    EXPECT_TRUE(vertexData[i].normal == nor_view[i]);
+    EXPECT_TRUE(vertexData[i].color == col_view[i]);
   }
 
   auto pos_attr = data.getAttribute<GpuVec3>(VertexAttrib::Position);
@@ -90,14 +90,14 @@ GTEST_TEST(TestErasedBlob, custom_vertex) {
   std::span<const CustomVertex> view = data.viewAs<CustomVertex>();
   EXPECT_EQ(view.size(), size);
 
+  strided_view pos_view = data.getAttribute<Float4>(VertexAttrib::Position);
+  strided_view col_view = data.getAttribute<Float3>(VertexAttrib::Color0);
+  strided_view uv_view = data.getAttribute<Float2>(VertexAttrib::TexCoord0);
   for (Uint64 i = 0; i < size; i++) {
-    EXPECT_TRUE(view[i] == vertexData[i]);
-    EXPECT_TRUE(vertexData[i].pos ==
-                data.getAttribute<Float4>(i, VertexAttrib ::Position));
-    EXPECT_TRUE(vertexData[i].color ==
-                data.getAttribute<Float3>(i, VertexAttrib::Color0));
-    EXPECT_TRUE(vertexData[i].uv ==
-                data.getAttribute<Float2>(i, VertexAttrib::TexCoord0));
+    EXPECT_EQ(view[i], vertexData[i]);
+    EXPECT_EQ(vertexData[i].pos, pos_view[i]);
+    EXPECT_EQ(vertexData[i].color, col_view[i]);
+    EXPECT_EQ(vertexData[i].uv, uv_view[i]);
   }
 }
 

--- a/tests/TestStrided.cpp
+++ b/tests/TestStrided.cpp
@@ -1,0 +1,70 @@
+#include "candlewick/utils/StridedView.h"
+#include <gtest/gtest.h>
+#include <vector>
+#include <numeric>
+
+using candlewick::strided_view;
+
+GTEST_TEST(TestStridedView, c_array) {
+  using T = std::tuple<uint, float>;
+  T data[5] = {{0, 0.1f}, {10, 2.2f}, {0, 0.3f}, {12, -0.3f}, {0, -13.4f}};
+
+  strided_view<T> view(data, 2 * sizeof(T));
+  EXPECT_EQ(view.size(), sizeof(data) / sizeof(T));
+  EXPECT_EQ(view.stride_bytes(), 2 * sizeof(T));
+  EXPECT_EQ(view.max_index(), 3);
+  EXPECT_FALSE(view.empty());
+}
+
+GTEST_TEST(TestStridedView, vector_int) {
+  std::vector<int> data;
+  data.resize(11);
+  std::iota(data.begin(), data.end(), 0);
+
+  auto stride = 2 * sizeof(int);
+  auto view = strided_view(data.data(), data.size(), stride);
+  EXPECT_EQ(view.size(), data.size());
+  EXPECT_EQ(view.stride_bytes(), stride);
+  EXPECT_EQ(view.max_index(), 6);
+  EXPECT_FALSE(view.empty());
+
+  EXPECT_EQ(view.front(), 0);
+  EXPECT_EQ(view[1], 2);
+  EXPECT_EQ(view[2], 4);
+  EXPECT_EQ(view.at(3), 6);
+  EXPECT_EQ(view.at(4), 8);
+  EXPECT_EQ(view.at(5), 10);
+}
+
+struct test_data {
+  int a;
+  double b;
+};
+
+bool operator==(const test_data &x, const test_data &y) {
+  return x.a == y.a && x.b == y.b;
+}
+
+GTEST_TEST(TestStridedView, span) {
+  std::vector<test_data> data;
+  data.resize(11);
+
+  for (uint i = 0; i < 11; i++) {
+    data[i].a = int(i);
+    data[i].b = 3.f * float(i);
+  }
+
+  std::span<test_data> view0{data};
+
+  auto stride = 3 * sizeof(test_data);
+  strided_view view{view0, stride};
+  EXPECT_EQ(view.size(), data.size());
+  EXPECT_EQ(view.stride_bytes(), stride);
+  EXPECT_FALSE(view.empty());
+
+  EXPECT_EQ(view[0], view.front());
+  EXPECT_EQ(view[0], data[0]);
+  EXPECT_EQ(view[1], data[3]);
+  EXPECT_EQ(view[2], data[6]);
+  EXPECT_EQ(view.at(3), data.at(9));
+}

--- a/tests/TestStrided.cpp
+++ b/tests/TestStrided.cpp
@@ -34,6 +34,7 @@ GTEST_TEST(TestStridedView, vector_int) {
   EXPECT_EQ(view.at(3), 6);
   EXPECT_EQ(view.at(4), 8);
   EXPECT_EQ(view.at(5), 10);
+  EXPECT_THROW((void)view.at(6), std::out_of_range);
 }
 
 struct test_data {
@@ -67,4 +68,5 @@ GTEST_TEST(TestStridedView, span) {
   EXPECT_EQ(view[1], data[3]);
   EXPECT_EQ(view[2], data[6]);
   EXPECT_EQ(view.at(3), data.at(9));
+  EXPECT_THROW((void)view.at(4), std::out_of_range);
 }

--- a/tests/TestStrided.cpp
+++ b/tests/TestStrided.cpp
@@ -22,7 +22,7 @@ GTEST_TEST(TestStridedView, vector_int) {
   std::iota(data.begin(), data.end(), 0);
 
   auto stride = 2 * sizeof(int);
-  auto view = strided_view(data.data(), data.size(), stride);
+  strided_view<const int> view{data.data(), data.size(), stride};
   EXPECT_EQ(view.size(), data.size());
   EXPECT_EQ(view.stride_bytes(), stride);
   EXPECT_EQ(view.max_index(), 6);
@@ -35,6 +35,13 @@ GTEST_TEST(TestStridedView, vector_int) {
   EXPECT_EQ(view.at(4), 8);
   EXPECT_EQ(view.at(5), 10);
   EXPECT_THROW((void)view.at(6), std::out_of_range);
+
+  int count = 0;
+  for (auto it = view.begin(); it != view.end(); it++) {
+    EXPECT_EQ(*it, count);
+    count += 2;
+  }
+  EXPECT_EQ(count, 2 * view.max_index());
 }
 
 struct test_data {


### PR DESCRIPTION
This PR adds a `strided_view<T>` template class corresponding to a **strided version of** `std::span<T>`. This is meant to look at non-contiguous (but evenly-strided) data such as interleaved vertex attributes.
+ [utils] MeshData : change signature of getAttribute(), now returns a `candlewick::strided_view</*const*/T>`

Also:
- add support for `coal::GEOM_ELLIPSOID`
- add support for `coal::GEOM_CONVEX`
- add loader `loadCoalConvex()`
- change signature of `loadCoalPrimitive()` to take `coal::ShapeBase`