### PR TITLE
[core] Revamp SSAO, depth and shadow map pass classes - add move constructors, assignment op, and destructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - multibody/RobotScene : reorganize pipelines (accomodate for transparent PBR shader)
 - shaders : refactor basic PBR shader (move some functions to new `pbr_lighting.glsl`) (https://github.com/Simple-Robotics/candlewick/pull/58)
 - interleave debug scene render between robot render system opaque and transparent passes (https://github.com/Simple-Robotics/candlewick/pull/59)
-- revamp depth and shadow map pass classes
+- revamp depth and shadow map pass classes (https://github.com/Simple-Robotics/candlewick/pull/60)
+- core/Texture : do not store pointer to `Device` but raw `SDL_GPUDevice *` handle (https://github.com/Simple-Robotics/candlewick/pull/60)
 
 ## [0.0.6] - 2025-05-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - multibody/RobotScene : early return if pipeline is nullptr (https://github.com/Simple-Robotics/candlewick/pull/58)
 - multibody/RobotScene : reorganize pipelines (accomodate for transparent PBR shader)
 - shaders : refactor basic PBR shader (move some functions to new `pbr_lighting.glsl`) (https://github.com/Simple-Robotics/candlewick/pull/58)
-- interleave debug scene render between robot render system opaque and transparent passes
+- interleave debug scene render between robot render system opaque and transparent passes (https://github.com/Simple-Robotics/candlewick/pull/59)
+- revamp depth and shadow map pass classes
 
 ## [0.0.6] - 2025-05-14
 

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -5,7 +5,12 @@ endif(GENERATE_PYTHON_STUBS)
 
 find_package(eigenpy 3.2.0 REQUIRED)
 
-set(pycandlewick_SOURCES src/expose-renderer.cpp src/module.cpp)
+set(
+  pycandlewick_SOURCES
+  src/expose-mesh-data.cpp
+  src/expose-renderer.cpp
+  src/module.cpp
+)
 
 set(PYLIB_INSTALL_DIR ${PYTHON_SITELIB}/${PROJECT_NAME})
 

--- a/bindings/python/src/expose-mesh-data.cpp
+++ b/bindings/python/src/expose-mesh-data.cpp
@@ -1,0 +1,22 @@
+#include "fwd.hpp"
+#include "candlewick/utils/MeshData.h"
+
+using namespace candlewick;
+
+void exposeMeshData() {
+
+  bp::class_<MeshLayout>("MeshLayout", bp::no_init);
+
+  bp::class_<MeshData, boost::noncopyable>("MeshData", bp::no_init)
+      .def_readonly("layout", &MeshData::layout)
+      .add_property("numVertices", &MeshData::numVertices,
+                    "Number of vertices.")
+      .add_property("vertexSize", &MeshData::vertexSize)
+      .add_property("vertexBytes", &MeshData::vertexBytes,
+                    "Number of bytes in the vertex data.")
+      .add_property("numIndices", &MeshData::numIndices, "Number of indices.")
+      .add_property("isIndexed", &MeshData::isIndexed,
+                    "Whether the mesh is indexed.")
+
+      ;
+}

--- a/bindings/python/src/expose-visualizer.cpp
+++ b/bindings/python/src/expose-visualizer.cpp
@@ -10,34 +10,32 @@
 
 using namespace candlewick::multibody;
 
+#define DEF_PROP_PROXY(name)                                                   \
+  add_property(#name, bp::make_function(                                       \
+                          +[](Visualizer &v) -> auto & { return v.name(); },   \
+                          bp::return_internal_reference<>()))
+
 void exposeVisualizer() {
   eigenpy::OptionalConverter<ConstVectorRef, std::optional>::registration();
   bp::class_<Visualizer::Config>("VisualizerConfig", bp::init<>())
       .def_readwrite("width", &Visualizer::Config::width)
       .def_readwrite("height", &Visualizer::Config::height);
 
-  auto cl =
-      bp::class_<Visualizer, boost::noncopyable>("Visualizer", bp::no_init)
-          .def(bp::init<Visualizer::Config, const pin::Model &,
-                        const pin::GeometryModel &>(
-              ("self"_a, "config", "model", "geomModel")))
-          .def(pinocchio::python::VisualizerPythonVisitor<Visualizer>{})
-          .def_readonly("renderer", &Visualizer::renderer)
-          .add_property("shouldExit", &Visualizer::shouldExit);
-
+  bp::class_<Visualizer, boost::noncopyable>("Visualizer", bp::no_init)
+      .def(bp::init<Visualizer::Config, const pin::Model &,
+                    const pin::GeometryModel &>(
+          ("self"_a, "config", "model", "geomModel")))
+      .def(pinocchio::python::VisualizerPythonVisitor<Visualizer>{})
+      .def_readonly("renderer", &Visualizer::renderer)
 // fix for Pinocchio 3.5.0
 #if PINOCCHIO_VERSION_AT_MOST(3, 5, 0)
-#define DEF_PROP_PROXY(name)                                                   \
-  add_property(#name, bp::make_function(                                       \
-                          +[](Visualizer &v) -> auto & { return v.name(); },   \
-                          bp::return_internal_reference<>()))
-  cl //
       .DEF_PROP_PROXY(model)
       .DEF_PROP_PROXY(visualModel)
       .DEF_PROP_PROXY(collisionModel)
       .DEF_PROP_PROXY(data)
       .DEF_PROP_PROXY(visualData)
-      .DEF_PROP_PROXY(collisionData);
-#undef DEF_PROP_PROXY
+      .DEF_PROP_PROXY(collisionData)
 #endif
+      .add_property("shouldExit", &Visualizer::shouldExit);
 }
+#undef DEF_PROP_PROXY

--- a/bindings/python/src/module.cpp
+++ b/bindings/python/src/module.cpp
@@ -6,10 +6,11 @@
 
 using namespace candlewick;
 
+void exposeMeshData();
+void exposeRenderer();
 #ifdef CANDLEWICK_PYTHON_PINOCCHIO_SUPPORT
 void exposeVisualizer();
 #endif
-void exposeRenderer();
 
 BOOST_PYTHON_MODULE(pycandlewick) {
   bp::import("eigenpy");
@@ -26,6 +27,7 @@ BOOST_PYTHON_MODULE(pycandlewick) {
   // Register SDL_Quit() as a function to call when interpreter exits.
   Py_AtExit(SDL_Quit);
 
+  exposeMeshData();
   exposeRenderer();
 #ifdef CANDLEWICK_PYTHON_PINOCCHIO_SUPPORT
   {

--- a/examples/Ur5WithSystems.cpp
+++ b/examples/Ur5WithSystems.cpp
@@ -300,12 +300,12 @@ int main(int argc, char **argv) {
   robot_debug.addFrameTriad(debug_scene, ee_frame_id);
   robot_debug.addFrameVelocityArrow(debug_scene, ee_frame_id);
 
-  auto depthPassInfo =
-      DepthPassInfo::create(renderer, plane_obj.mesh.layout(), NULL,
-                            {SDL_GPU_CULLMODE_NONE, 0.05f, 0.f, true, false});
+  DepthPass depthPass(renderer.device, plane_obj.mesh.layout(),
+                      renderer.depth_texture,
+                      {SDL_GPU_CULLMODE_NONE, 0.05f, 0.f, true, false});
   auto &shadowPassInfo = robot_scene.shadowPass;
   auto shadowDebugPass =
-      DepthDebugPass::create(renderer, shadowPassInfo.depthTexture);
+      DepthDebugPass::create(renderer, shadowPassInfo.shadowMap);
 
   auto depthDebugPass =
       DepthDebugPass::create(renderer, renderer.depth_texture);
@@ -464,7 +464,7 @@ int main(int argc, char **argv) {
       auto &castables = robot_scene.castables();
       renderShadowPassFromAABB(command_buffer, shadowPassInfo, sceneLight,
                                castables, worldSpaceBounds);
-      renderDepthOnlyPass(command_buffer, depthPassInfo, viewProj, castables);
+      depthPass.render(command_buffer, viewProj, castables);
       switch (g_showDebugViz) {
       case FULL_RENDER:
         robot_scene.renderOpaque(command_buffer, g_camera);
@@ -501,7 +501,7 @@ int main(int argc, char **argv) {
 
   SDL_WaitForGPUIdle(renderer.device);
   frustumBoundsDebug.release();
-  depthPassInfo.release();
+  depthPass.release();
   shadowDebugPass.release(renderer.device);
   depthDebugPass.release(renderer.device);
   robot_scene.release();

--- a/src/candlewick/core/Core.h
+++ b/src/candlewick/core/Core.h
@@ -9,7 +9,7 @@ namespace candlewick {
 struct Camera;
 class CommandBuffer;
 struct Device;
-struct Texture;
+class Texture;
 class Mesh;
 class MeshView;
 class MeshLayout;

--- a/src/candlewick/core/Texture.cpp
+++ b/src/candlewick/core/Texture.cpp
@@ -9,10 +9,10 @@ namespace candlewick {
 
 Texture::Texture(const Device &device, SDL_GPUTextureCreateInfo texture_desc,
                  const char *name)
-    : _texture(nullptr)
-    , _device(&device)
+    : _device(device)
+    , _texture(nullptr)
     , _description(std::move(texture_desc)) {
-  if (!(_texture = SDL_CreateGPUTexture(*_device, &_description))) {
+  if (!(_texture = SDL_CreateGPUTexture(_device, &_description))) {
     std::string msg = std::format("Failed to create texture with format (%s)",
                                   magic_enum::enum_name(_description.format));
     if (name)
@@ -20,14 +20,13 @@ Texture::Texture(const Device &device, SDL_GPUTextureCreateInfo texture_desc,
     throw RAIIException(std::move(msg));
   }
   if (name != nullptr)
-    SDL_SetGPUTextureName(*_device, _texture, name);
+    SDL_SetGPUTextureName(_device, _texture, name);
 }
 
-Texture::Texture(Texture &&other) noexcept {
-  _device = other._device;
-  _texture = other._texture;
-  _description = std::move(other._description);
-
+Texture::Texture(Texture &&other) noexcept
+    : _device(other._device)
+    , _texture(other._texture)
+    , _description(std::move(other._description)) {
   other._device = nullptr;
   other._texture = nullptr;
 }
@@ -63,11 +62,9 @@ Uint32 Texture::textureSize() const {
                                            depth());
 }
 
-const Device &Texture::device() const { return *_device; }
-
 void Texture::destroy() noexcept {
   if (_device && _texture) {
-    SDL_ReleaseGPUTexture(*_device, _texture);
+    SDL_ReleaseGPUTexture(_device, _texture);
     _texture = nullptr;
     _device = nullptr;
   }

--- a/src/candlewick/core/Texture.h
+++ b/src/candlewick/core/Texture.h
@@ -6,8 +6,13 @@
 
 namespace candlewick {
 
-struct Texture {
-  Texture(NoInitT);
+class Texture {
+  SDL_GPUDevice *_device = nullptr;
+  SDL_GPUTexture *_texture = nullptr;
+  SDL_GPUTextureCreateInfo _description;
+
+public:
+  Texture(NoInitT) {}
   Texture(const Device &device, SDL_GPUTextureCreateInfo texture_desc,
           const char *name = nullptr);
 
@@ -33,17 +38,8 @@ struct Texture {
 
   Uint32 textureSize() const;
 
-  const Device &device() const;
-
   void destroy() noexcept;
   ~Texture() noexcept { this->destroy(); }
-
-private:
-  SDL_GPUTexture *_texture;
-  Device const *_device;
-  SDL_GPUTextureCreateInfo _description;
 };
-
-inline Texture::Texture(NoInitT) : _texture(nullptr), _device(nullptr) {}
 
 } // namespace candlewick

--- a/src/candlewick/multibody/RobotScene.cpp
+++ b/src/candlewick/multibody/RobotScene.cpp
@@ -241,6 +241,7 @@ void RobotScene::loadModels(const pin::GeometryModel &geom_model,
 
   // initialize render target for GBuffer
   const bool enable_shadows = m_config.enable_shadows;
+  bool shadows_configured = false;
 
   for (pin::GeomIndex geom_id = 0; geom_id < geom_model.ngeoms; geom_id++) {
 
@@ -273,9 +274,10 @@ void RobotScene::loadModels(const pin::GeometryModel &geom_model,
         ssaoPass = ssao::SsaoPass(m_renderer, layout, gBuffer.normalMap);
       }
       // configure shadow pass
-      if (enable_shadows && !shadowPass.pipeline) {
-        shadowPass =
-            ShadowPassInfo::create(m_renderer, layout, m_config.shadow_config);
+      if (enable_shadows && !shadows_configured) {
+        shadowPass = ShadowMapPass(device(), layout, m_renderer.depthFormat(),
+                                   m_config.shadow_config);
+        shadows_configured = true;
       }
       this->initCompositePipeline(layout);
     }
@@ -449,7 +451,7 @@ void RobotScene::renderPBRTriangleGeometry(CommandBuffer &command_buffer,
   if (enable_shadows) {
     rend::bindFragmentSamplers(render_pass, SHADOW_MAP_SLOT,
                                {{
-                                   .texture = shadowPass.depthTexture,
+                                   .texture = shadowPass.shadowMap,
                                    .sampler = shadowPass.sampler,
                                }});
   }

--- a/src/candlewick/multibody/RobotScene.cpp
+++ b/src/candlewick/multibody/RobotScene.cpp
@@ -271,7 +271,7 @@ void RobotScene::loadModels(const pin::GeometryModel &geom_model,
 
     if (pipeline_type == PIPELINE_TRIANGLEMESH) {
       if (!ssaoPass.pipeline) {
-        ssaoPass = ssao::SsaoPass(m_renderer, layout, gBuffer.normalMap);
+        ssaoPass = ssao::SsaoPass(m_renderer, gBuffer.normalMap);
       }
       // configure shadow pass
       if (enable_shadows && !shadows_configured) {

--- a/src/candlewick/multibody/RobotScene.h
+++ b/src/candlewick/multibody/RobotScene.h
@@ -148,7 +148,7 @@ namespace multibody {
       Texture revealTexture{NoInit};
       SDL_GPUSampler *sampler = nullptr; // composite pass
     } gBuffer;
-    ShadowPassInfo shadowPass;
+    ShadowMapPass shadowPass{NoInit};
     AABB worldSpaceBounds;
 
     /// \brief Non-initializing constructor.

--- a/src/candlewick/posteffects/SSAO.h
+++ b/src/candlewick/posteffects/SSAO.h
@@ -7,31 +7,34 @@
 namespace candlewick {
 namespace ssao {
   struct SsaoPass {
+    SDL_GPUDevice *_device = nullptr;
     SDL_GPUTexture *inDepthMap = nullptr;
     SDL_GPUTexture *inNormalMap = nullptr;
     SDL_GPUSampler *texSampler = nullptr;
     SDL_GPUGraphicsPipeline *pipeline = nullptr;
     Texture ssaoMap{NoInit};
-
     struct SsaoNoise {
       Texture tex{NoInit};
       SDL_GPUSampler *sampler = nullptr;
       // The texture will be N x N where N is this value.
       Uint32 pixel_window_size;
     } ssaoNoise;
-
     SDL_GPUGraphicsPipeline *blurPipeline = nullptr;
     // first blur pass target
     Texture blurPass1Tex{NoInit};
 
     SsaoPass(NoInitT) {}
-    SsaoPass(const Renderer &renderer, const MeshLayout &layout,
-             SDL_GPUTexture *normalMap);
+    SsaoPass(const Renderer &renderer, SDL_GPUTexture *normalMap);
+
+    SsaoPass(SsaoPass &&other) noexcept;
+    SsaoPass &operator=(SsaoPass &&other) noexcept;
 
     void render(CommandBuffer &cmdBuf, const Camera &camera);
 
     // cleanup function
-    void release();
+    void release() noexcept;
+
+    ~SsaoPass() noexcept { this->release(); }
   };
 
 } // namespace ssao


### PR DESCRIPTION
- **[bindings/python] expose MeshData, don't know how I'll use it**
- **core : Revamp depth and shadow map pass classes**
