### PR TITLE
Fix hangs when `Renderer` or `Visualizer` are destroyed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- core: `Renderer` : fix not cleaning up depth texture if non-null (*critical*)
+
 ### Changed
 
 - core : set max number of directional lights to 4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - core: `Renderer` : fix not cleaning up depth texture if non-null (*critical*)
+- core : `DebugScene` : fix not setting pipeline handles to nullptr
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - core: `Renderer` : fix not cleaning up depth texture if non-null (*critical*)
 - core : `DebugScene` : fix not setting pipeline handles to nullptr
+- multibody/Visualizer : fix not releasing transfer buffers before destroying render context (*critical*)
 
 ### Changed
 

--- a/examples/Visualizer.cpp
+++ b/examples/Visualizer.cpp
@@ -49,4 +49,5 @@ int main(int argc, char **argv) {
 
     t += dt;
   }
+  return 0;
 }

--- a/src/candlewick/core/DebugScene.cpp
+++ b/src/candlewick/core/DebugScene.cpp
@@ -140,9 +140,13 @@ void DebugScene::render(CommandBuffer &cmdBuf, const Camera &camera) const {
 }
 
 void DebugScene::release() {
-  if (device()) {
+  if (device() && _trianglePipeline) {
     SDL_ReleaseGPUGraphicsPipeline(device(), _trianglePipeline);
+    _trianglePipeline = nullptr;
+  }
+  if (device() && _linePipeline) {
     SDL_ReleaseGPUGraphicsPipeline(device(), _linePipeline);
+    _linePipeline = nullptr;
   }
   // clean up all DebugMeshComponent objects.
   _registry.clear<DebugMeshComponent>();

--- a/src/candlewick/core/Renderer.cpp
+++ b/src/candlewick/core/Renderer.cpp
@@ -67,15 +67,13 @@ bool Renderer::acquireSwapchain(CommandBuffer &command_buffer) {
                                         NULL, NULL);
 }
 
-void Renderer::destroy() noexcept {
+Renderer::~Renderer() noexcept {
   if (device && window) {
     SDL_ReleaseWindowFromGPUDevice(device, window);
   }
-  if (device && depth_texture) {
-    depth_texture.destroy();
-  }
-  device.destroy();
+  depth_texture.destroy();
   window.destroy();
+  device.destroy();
 }
 
 namespace rend {

--- a/src/candlewick/core/Renderer.cpp
+++ b/src/candlewick/core/Renderer.cpp
@@ -71,6 +71,9 @@ void Renderer::destroy() noexcept {
   if (device && window) {
     SDL_ReleaseWindowFromGPUDevice(device, window);
   }
+  if (device && depth_texture) {
+    depth_texture.destroy();
+  }
   device.destroy();
   window.destroy();
 }

--- a/src/candlewick/core/Renderer.h
+++ b/src/candlewick/core/Renderer.h
@@ -59,9 +59,9 @@ struct Renderer {
 
   SDL_GPUTextureFormat depthFormat() const { return depth_texture.format(); }
 
-  void destroy() noexcept;
+  ~Renderer() noexcept;
 
-  ~Renderer() noexcept { this->destroy(); }
+  void destroy() noexcept { this->~Renderer(); }
 };
 
 namespace rend {

--- a/src/candlewick/multibody/Visualizer.cpp
+++ b/src/candlewick/multibody/Visualizer.cpp
@@ -122,6 +122,7 @@ void Visualizer::setCameraPose(const Eigen::Ref<const Matrix4> &pose) {
 Visualizer::~Visualizer() {
   if (m_videoRecorder.isRecording())
     this->stopRecording();
+  m_transferBuffers.release();
 
   robotScene.release();
   debugScene.release();


### PR DESCRIPTION
- **imgui : sync submodule**
- **core: `Renderer` : fix not cleaning up depth texture if non-null**
- **core : `DebugScene` : fix not setting pipeline handles to nullptr**
- **multibody/Visualizer : fix not releasing transfer buffers before destroying render context**
- **core/Renderer : impl the dtor, use it in destroy()**
