### PR TITLE
multibody : deprecate header `<candlewick/multibody/Components.h>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- core/DebugScene : clean up entities with `DebugMeshComponent`
+
+### Changed
+
+- core/DebugScene : pass `Float3` scale to `addTriad()`
+
+### Removed
+
+- remove default plane from Visualizer class
+
+**Python**
+- Removed `multibody` submodule. All symbols included in the main module.
+- Fix stubs being generated for non-extension module classes/functions
+
 ## [0.3.1] - 2025-06-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - core/DebugScene : pass `Float3` scale to `addTriad()`
+- multibody : deprecate header `<candlewick/multibody/Components.h>`
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - core/DebugScene : clean up entities with `DebugMeshComponent`
+- core/`DebugScene` : add move ctor, explicitly delete move assignment op
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - utils/VideoRecorder.cpp : fix `m_frameCounter` not being initialized
 - bindings/python : fix recorder context helper
 
+### Changed
+
+- rename macro `CDW_ASSERT` to `CANDLEWICK_ASSERT` (for consistency)
+
 ## [0.3.0] - 2025-06-05
 
 ### Added

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -51,8 +51,8 @@ if(GENERATE_PYTHON_STUBS)
   LOAD_STUBGEN()
   GENERATE_STUBS(
     ${CMAKE_CURRENT_BINARY_DIR}
-    ${PROJECT_NAME}
-    ${PYTHON_SITELIB}
+    ${PROJECT_NAME}.pycandlewick
+    ${PYTHON_SITELIB}/candlewick
     pycandlewick
   )
 endif(GENERATE_PYTHON_STUBS)

--- a/bindings/python/candlewick/video_context.py
+++ b/bindings/python/candlewick/video_context.py
@@ -1,4 +1,4 @@
-from .pycandlewick.multibody import Visualizer
+from . import Visualizer
 from contextlib import contextmanager
 
 

--- a/bindings/python/src/module.cpp
+++ b/bindings/python/src/module.cpp
@@ -30,9 +30,6 @@ BOOST_PYTHON_MODULE(pycandlewick) {
   exposeMeshData();
   exposeRenderer();
 #ifdef CANDLEWICK_PYTHON_PINOCCHIO_SUPPORT
-  {
-    bp::scope submod = get_namespace("multibody");
-    exposeVisualizer();
-  }
+  exposeVisualizer();
 #endif
 }

--- a/examples/python/go2.py
+++ b/examples/python/go2.py
@@ -1,5 +1,5 @@
 import candlewick as cdw
-from candlewick.multibody import Visualizer, VisualizerConfig
+from candlewick import Visualizer, VisualizerConfig
 
 try:
     import go2_description as go2d

--- a/examples/python/show_robot_description.py
+++ b/examples/python/show_robot_description.py
@@ -15,7 +15,7 @@ import argparse
 
 import pinocchio as pin
 
-from candlewick.multibody import Visualizer, VisualizerConfig
+from candlewick import Visualizer, VisualizerConfig
 
 try:
     from robot_descriptions.loaders.pinocchio import load_robot_description

--- a/examples/python/ur10_loop.py
+++ b/examples/python/ur10_loop.py
@@ -2,7 +2,7 @@ import example_robot_data as erd
 import pinocchio as pin
 import time
 import numpy as np
-from candlewick.multibody import Visualizer, VisualizerConfig
+from candlewick import Visualizer, VisualizerConfig
 
 robot = erd.load("ur10")
 model: pin.Model = robot.model

--- a/src/candlewick/core/Core.h
+++ b/src/candlewick/core/Core.h
@@ -3,7 +3,7 @@
 #include <coal/fwd.hh>
 #include <cassert>
 
-#define CDW_ASSERT(condition, msg) assert(((condition) && (msg)))
+#define CANDLEWICK_ASSERT(condition, msg) assert(((condition) && (msg)))
 
 namespace candlewick {
 struct Camera;

--- a/src/candlewick/core/DebugScene.cpp
+++ b/src/candlewick/core/DebugScene.cpp
@@ -148,6 +148,7 @@ void DebugScene::release() {
     m_linePipeline = nullptr;
   }
   // clean up all DebugMeshComponent objects.
-  m_registry.clear<DebugMeshComponent>();
+  auto view = m_registry.group<DebugMeshComponent>();
+  m_registry.destroy(view.begin(), view.end());
 }
 } // namespace candlewick

--- a/src/candlewick/core/DebugScene.cpp
+++ b/src/candlewick/core/DebugScene.cpp
@@ -14,6 +14,16 @@ DebugScene::DebugScene(entt::registry &reg, const RenderContext &renderer)
     , m_trianglePipeline(nullptr)
     , m_linePipeline(nullptr) {}
 
+DebugScene::DebugScene(DebugScene &&other)
+    : m_registry(other.m_registry)
+    , m_renderer(other.m_renderer)
+    , m_trianglePipeline(other.m_trianglePipeline)
+    , m_linePipeline(other.m_linePipeline)
+    , m_subsystems(std::move(other.m_subsystems)) {
+  other.m_trianglePipeline = nullptr;
+  other.m_linePipeline = nullptr;
+}
+
 std::tuple<entt::entity, DebugMeshComponent &>
 DebugScene::addTriad(const Float3 &scale) {
   auto triad_datas = loadTriadSolid();

--- a/src/candlewick/core/DebugScene.h
+++ b/src/candlewick/core/DebugScene.h
@@ -40,12 +40,11 @@ struct DebugMeshComponent {
 ///
 /// This implements a basic render system for DebugMeshComponent.
 class DebugScene {
-  entt::registry &_registry;
-  const RenderContext &_renderer;
-  SDL_GPUGraphicsPipeline *_trianglePipeline;
-  SDL_GPUGraphicsPipeline *_linePipeline;
-  SDL_GPUTextureFormat _swapchainTextureFormat, _depthFormat;
-  std::vector<std::unique_ptr<IDebugSubSystem>> _systems;
+  entt::registry &m_registry;
+  const RenderContext &m_renderer;
+  SDL_GPUGraphicsPipeline *m_trianglePipeline;
+  SDL_GPUGraphicsPipeline *m_linePipeline;
+  std::vector<std::unique_ptr<IDebugSubSystem>> m_subsystems;
 
   void renderMeshComponents(CommandBuffer &cmdBuf,
                             SDL_GPURenderPass *render_pass,
@@ -59,29 +58,30 @@ public:
   DebugScene(const DebugScene &) = delete;
   DebugScene &operator=(const DebugScene &) = delete;
 
-  const Device &device() const noexcept { return _renderer.device; }
-  entt::registry &registry() { return _registry; }
-  const entt::registry &registry() const { return _registry; }
+  const Device &device() const noexcept { return m_renderer.device; }
+  entt::registry &registry() { return m_registry; }
+  const entt::registry &registry() const { return m_registry; }
 
   /// \brief Add a subsystem (IDebugSubSystem) to the scene.
   template <std::derived_from<IDebugSubSystem> System, typename... Args>
   System &addSystem(Args &&...args) {
     auto sys = std::make_unique<System>(std::forward<Args>(args)...);
-    _systems.push_back(std::move(sys));
-    return static_cast<System &>(*_systems.back());
+    m_subsystems.push_back(std::move(sys));
+    return static_cast<System &>(*m_subsystems.back());
   }
 
   /// \brief Setup pipelines; this will only have an effect **ONCE**.
   void setupPipelines(const MeshLayout &layout);
 
   /// \brief Just the basic 3D triad.
-  std::tuple<entt::entity, DebugMeshComponent &> addTriad();
+  std::tuple<entt::entity, DebugMeshComponent &>
+  addTriad(const Float3 &scale = Float3::Ones());
   /// \brief Add a basic line grid.
   std::tuple<entt::entity, DebugMeshComponent &>
   addLineGrid(std::optional<Float4> color = std::nullopt);
 
   void update() {
-    for (auto &system : _systems) {
+    for (auto &system : m_subsystems) {
       system->update(*this);
     }
   }

--- a/src/candlewick/core/DebugScene.h
+++ b/src/candlewick/core/DebugScene.h
@@ -46,10 +46,6 @@ class DebugScene {
   SDL_GPUGraphicsPipeline *m_linePipeline;
   std::vector<std::unique_ptr<IDebugSubSystem>> m_subsystems;
 
-  void renderMeshComponents(CommandBuffer &cmdBuf,
-                            SDL_GPURenderPass *render_pass,
-                            const Camera &camera) const;
-
 public:
   enum { TRANSFORM_SLOT = 0 };
   enum { COLOR_SLOT = 0 };

--- a/src/candlewick/core/DebugScene.h
+++ b/src/candlewick/core/DebugScene.h
@@ -66,8 +66,8 @@ public:
   template <std::derived_from<IDebugSubSystem> System, typename... Args>
   System &addSystem(Args &&...args) {
     auto sys = std::make_unique<System>(std::forward<Args>(args)...);
-    m_subsystems.push_back(std::move(sys));
-    return static_cast<System &>(*m_subsystems.back());
+    auto &p = m_subsystems.emplace_back(std::move(sys));
+    return static_cast<System &>(*p);
   }
 
   /// \brief Setup pipelines; this will only have an effect **ONCE**.

--- a/src/candlewick/core/DebugScene.h
+++ b/src/candlewick/core/DebugScene.h
@@ -27,10 +27,12 @@ struct IDebugSubSystem {
   virtual ~IDebugSubSystem() = default;
 };
 
+/// \brief Component for simple mesh with colors.
+///
+/// This is meant for the \c Hud3dElement shader.
 struct DebugMeshComponent {
   DebugPipelines pipeline_type;
   Mesh mesh;
-  // fragment shader
   std::vector<GpuVec4> colors;
   bool enable = true;
   Float3 scale = Float3::Ones();
@@ -42,8 +44,8 @@ struct DebugMeshComponent {
 class DebugScene {
   entt::registry &m_registry;
   const RenderContext &m_renderer;
-  SDL_GPUGraphicsPipeline *m_trianglePipeline;
-  SDL_GPUGraphicsPipeline *m_linePipeline;
+  SDL_GPUGraphicsPipeline *m_trianglePipeline{nullptr};
+  SDL_GPUGraphicsPipeline *m_linePipeline{nullptr};
   std::vector<std::unique_ptr<IDebugSubSystem>> m_subsystems;
 
 public:
@@ -53,6 +55,8 @@ public:
   DebugScene(entt::registry &registry, const RenderContext &renderer);
   DebugScene(const DebugScene &) = delete;
   DebugScene &operator=(const DebugScene &) = delete;
+  DebugScene(DebugScene &&other);
+  DebugScene &operator=(DebugScene &&) = delete;
 
   const Device &device() const noexcept { return m_renderer.device; }
   entt::registry &registry() { return m_registry; }

--- a/src/candlewick/core/Mesh.cpp
+++ b/src/candlewick/core/Mesh.cpp
@@ -16,10 +16,10 @@ MeshView::MeshView(const MeshView &parent, Uint32 subVertexOffset,
     , indexOffset(parent.indexOffset + subIndexOffset)
     , indexCount(subIndexCount) {
   // assumption: parent MeshView is validated
-  CDW_ASSERT(validateMeshView(*this), "MeshView failed validation.");
-  CDW_ASSERT(subVertexOffset + subVertexCount <= parent.vertexCount &&
-                 subIndexOffset + subIndexCount <= parent.indexCount,
-             "");
+  CANDLEWICK_ASSERT(validateMeshView(*this), "MeshView failed validation.");
+  CANDLEWICK_ASSERT(subVertexOffset + subVertexCount <= parent.vertexCount &&
+                        subIndexOffset + subIndexCount <= parent.indexCount,
+                    "");
 }
 
 Mesh::Mesh(NoInitT) {}

--- a/src/candlewick/core/Texture.cpp
+++ b/src/candlewick/core/Texture.cpp
@@ -44,8 +44,8 @@ Texture &Texture::operator=(Texture &&other) noexcept {
 
 SDL_GPUBlitRegion Texture::blitRegion(Uint32 x, Uint32 y,
                                       Uint32 layer_or_depth_plane) const {
-  CDW_ASSERT(layer_or_depth_plane < layerCount(),
-             "layer is higher than layerCount!");
+  CANDLEWICK_ASSERT(layer_or_depth_plane < layerCount(),
+                    "layer is higher than layerCount!");
   return {
       .texture = _texture,
       .mip_level = 0,

--- a/src/candlewick/multibody/Components.h
+++ b/src/candlewick/multibody/Components.h
@@ -1,25 +1,7 @@
 #pragma once
 
-#include <pinocchio/multibody/fwd.hpp>
+#include "candlewick/deprecated.h"
+#include "Multibody.h"
 
-namespace candlewick::multibody {
-namespace pin = pinocchio;
-
-struct PinGeomObjComponent {
-  pin::GeomIndex geom_index;
-  operator auto() const { return geom_index; }
-};
-
-struct PinFrameComponent {
-  pin::FrameIndex frame_id;
-  operator auto() const { return frame_id; }
-};
-
-/// Similar to PinFrameComponent, but tags the entity to render the frame
-/// velocity - not its placement as e.g. a triad.
-struct PinFrameVelocityComponent {
-  pin::FrameIndex frame_id;
-  operator auto() const { return frame_id; }
-};
-
-} // namespace candlewick::multibody
+CANDLEWICK_DEPRECATED_HEADER(
+    "Header is deprecated. Just include <candlewick/multibody/Multibody.h>")

--- a/src/candlewick/multibody/LoadCoalGeometries.cpp
+++ b/src/candlewick/multibody/LoadCoalGeometries.cpp
@@ -82,8 +82,8 @@ MeshData loadCoalConvex(const coal::ConvexBase &geom_) {
 
 MeshData loadCoalPrimitive(const coal::ShapeBase &geometry) {
   using namespace coal;
-  CDW_ASSERT(geometry.getObjectType() == OT_GEOM,
-             "CollisionGeometry object type must be OT_GEOM !");
+  CANDLEWICK_ASSERT(geometry.getObjectType() == OT_GEOM,
+                    "CollisionGeometry object type must be OT_GEOM !");
   MeshData meshData{NoInit};
   Eigen::Affine3f transform = Eigen::Affine3f::Identity();
   const NODE_TYPE nodeType = geometry.getNodeType();

--- a/src/candlewick/multibody/Multibody.h
+++ b/src/candlewick/multibody/Multibody.h
@@ -26,5 +26,22 @@ namespace multibody {
   void guiAddPinocchioModelInfo(entt::registry &reg, const pin::Model &model,
                                 const pin::GeometryModel &geom_model,
                                 int table_height_lines = 6);
+
+  struct PinGeomObjComponent {
+    pin::GeomIndex geom_index;
+    operator auto() const { return geom_index; }
+  };
+
+  struct PinFrameComponent {
+    pin::FrameIndex frame_id;
+    operator auto() const { return frame_id; }
+  };
+
+  /// Similar to PinFrameComponent, but tags the entity to render the frame
+  /// velocity - not its placement as e.g. a triad.
+  struct PinFrameVelocityComponent {
+    pin::FrameIndex frame_id;
+    operator auto() const { return frame_id; }
+  };
 } // namespace multibody
 } // namespace candlewick

--- a/src/candlewick/multibody/RobotDebug.cpp
+++ b/src/candlewick/multibody/RobotDebug.cpp
@@ -10,8 +10,7 @@ entt::entity RobotDebugSystem::addFrameTriad(DebugScene &scene,
                                              pin::FrameIndex frame_id,
                                              const Float3 &scale) {
   entt::registry &reg = scene.registry();
-  auto [ent, triad] = scene.addTriad();
-  triad.scale = scale;
+  auto [ent, triad] = scene.addTriad(scale);
   reg.emplace<PinFrameComponent>(ent, frame_id);
   return ent;
 }

--- a/src/candlewick/multibody/RobotDebug.h
+++ b/src/candlewick/multibody/RobotDebug.h
@@ -22,8 +22,8 @@ struct RobotDebugSystem final : IDebugSubSystem {
   entt::entity addFrameVelocityArrow(DebugScene &scene,
                                      pin::FrameIndex frame_id);
 
-  /// \brief Update the visualization of the frame placements and their
-  /// velocities.
+  /// \brief Update the transform components for the debug visual entities,
+  /// according to their frame placements and velocities.
   ///
   /// \warning We expect pinocchio::updateFramePlacements() or
   /// pinocchio::framesForwardKinematics() to be called first!

--- a/src/candlewick/multibody/RobotDebug.h
+++ b/src/candlewick/multibody/RobotDebug.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Multibody.h"
-#include "Components.h"
 #include "../core/DebugScene.h"
 
 namespace candlewick::multibody {

--- a/src/candlewick/multibody/RobotScene.cpp
+++ b/src/candlewick/multibody/RobotScene.cpp
@@ -1,5 +1,4 @@
 #include "RobotScene.h"
-#include "Components.h"
 #include "LoadPinocchioGeometry.h"
 #include "../core/Components.h"
 #include "../core/Shader.h"

--- a/src/candlewick/multibody/RobotScene.h
+++ b/src/candlewick/multibody/RobotScene.h
@@ -167,7 +167,7 @@ namespace multibody {
     RobotScene(const RobotScene &) = delete;
 
     void setConfig(const Config &config) {
-      CDW_ASSERT(
+      CANDLEWICK_ASSERT(
           !m_initialized,
           "Cannot call setConfig() after render system was initialized.");
       m_config = config;

--- a/src/candlewick/multibody/Visualizer.cpp
+++ b/src/candlewick/multibody/Visualizer.cpp
@@ -92,13 +92,6 @@ void Visualizer::initialize() {
 
   worldSceneBounds.update({-1., -1., 0.}, {+1., +1., 1.});
 
-  const Uint32 prepeat = 25;
-  m_plane = robotScene.addEnvironmentObject(
-      loadPlaneTiled(0.5f, prepeat, prepeat), Mat4f::Identity());
-  if (!envStatus.show_plane) {
-    registry.emplace<Disable>(m_plane);
-  }
-
   this->resetCamera();
 
   SDL_Log("┌───────Controls────────");

--- a/src/candlewick/multibody/Visualizer.cpp
+++ b/src/candlewick/multibody/Visualizer.cpp
@@ -101,11 +101,15 @@ void Visualizer::initialize() {
 
   this->resetCamera();
 
-  SDL_Log(" Controls:");
-  SDL_Log(" ——————————————————————");
-  SDL_Log(" Toggle GUI:      [%s]", "H");
-  SDL_Log(" Pan camera:      [%s]",
+  SDL_Log("┌───────Controls────────");
+  SDL_Log("│ Toggle GUI:      [%s]", "H");
+  SDL_Log("│ Move camera:     [%s]",
+          sdlMouseButtonToString(cameraParams.mouseButtons.rotButton));
+  SDL_Log("│ Pan camera:      [%s]",
           sdlMouseButtonToString(cameraParams.mouseButtons.panButton));
+  SDL_Log("│ Y-rotate camera: [%s]",
+          sdlMouseButtonToString(cameraParams.mouseButtons.yRotButton));
+  SDL_Log("└───────────────────────");
 }
 
 void Visualizer::resetCamera() {

--- a/src/candlewick/multibody/Visualizer.h
+++ b/src/candlewick/multibody/Visualizer.h
@@ -35,7 +35,9 @@ struct CameraControlParams {
 
   // Mouse button modifiers
   struct MouseConfig {
+    Uint8 rotButton = SDL_BUTTON_LEFT;
     Uint8 panButton = SDL_BUTTON_MIDDLE;
+    Uint8 yRotButton = SDL_BUTTON_RIGHT;
   } mouseButtons;
 };
 

--- a/src/candlewick/multibody/Visualizer.h
+++ b/src/candlewick/multibody/Visualizer.h
@@ -53,7 +53,7 @@ class Visualizer final : public BaseVisualizer {
   bool m_cameraControl = true;
   bool m_showGui = true;
   bool m_shouldExit = false;
-  entt::entity m_plane, m_grid, m_triad;
+  entt::entity m_grid, m_triad;
   std::string m_currentScreenshotFilename{};
   std::string m_currentVideoFilename{};
 
@@ -77,7 +77,6 @@ public:
   struct EnvStatus {
     bool show_our_about = false;
     bool show_imgui_about = false;
-    bool show_plane = false;
   };
 
   using BaseVisualizer::setCameraPose;

--- a/src/candlewick/multibody/internal/pinocchio_info_gui.cpp
+++ b/src/candlewick/multibody/internal/pinocchio_info_gui.cpp
@@ -1,5 +1,4 @@
 #include "candlewick/multibody/Multibody.h"
-#include "candlewick/multibody/Components.h"
 #include "candlewick/core/Components.h"
 #include "candlewick/core/GuiSystem.h"
 #include "candlewick/core/errors.h"

--- a/src/candlewick/multibody/internal/pinocchio_info_gui.cpp
+++ b/src/candlewick/multibody/internal/pinocchio_info_gui.cpp
@@ -120,7 +120,7 @@ void guiAddPinocchioModelInfo(entt::registry &reg, const pin::Model &model,
       coal::NODE_TYPE nodeType = coll.getNodeType();
       ImGui::TableNextRow();
       ImGui::TableSetColumnIndex(0);
-      ImGui::Text("%zu", id.geom_index);
+      ImGui::Text("%zu", id);
       ImGui::TableNextColumn();
       ImGui::Text("%s", gobj.name.c_str());
       ImGui::TableNextColumn();
@@ -134,7 +134,7 @@ void guiAddPinocchioModelInfo(entt::registry &reg, const pin::Model &model,
       ImGui::TableNextColumn();
       char chk_label[32];
       bool enabled = !disabled.contains(ent);
-      SDL_snprintf(chk_label, 32, "###enabled%zu", id.geom_index);
+      SDL_snprintf(chk_label, 32, "###enabled%zu", id);
       guiAddDisableCheckbox(chk_label, reg, ent, enabled);
     }
     ImGui::EndTable();

--- a/src/candlewick/multibody/internal/visualizer_gui.cpp
+++ b/src/candlewick/multibody/internal/visualizer_gui.cpp
@@ -94,9 +94,6 @@ void Visualizer::defaultGuiCallback() {
                         ImGuiColorEditFlags_AlphaPreview);
     }
     addDebugCheckbox("triad", m_triad);
-    ImGui::SameLine();
-    guiAddDisableCheckbox("Render plane", registry, m_plane,
-                          envStatus.show_plane);
   }
 
   if (ImGui::CollapsingHeader("Robot model info",

--- a/src/candlewick/multibody/internal/visualizer_gui.cpp
+++ b/src/candlewick/multibody/internal/visualizer_gui.cpp
@@ -153,14 +153,14 @@ static void mouse_motion_handler(CylindricalCamera &controller,
   Float2 mvt{event.xrel, event.yrel};
   SDL_MouseButtonFlags mb = event.state;
   // check if left mouse pressed
-  if (mb & SDL_BUTTON_LMASK) {
+  if (mb & SDL_BUTTON_MASK(params.mouseButtons.rotButton)) {
     controller.viewportDrag(mvt, params.rotSensitivity, params.panSensitivity,
                             params.yInvert);
   }
   if (mb & SDL_BUTTON_MASK(params.mouseButtons.panButton)) {
     controller.pan(mvt, params.panSensitivity);
   }
-  if (mb & SDL_BUTTON_RMASK) {
+  if (mb & SDL_BUTTON_MASK(params.mouseButtons.yRotButton)) {
     Radf rot_angle = params.localRotSensitivity * mvt.y();
     camera_util::localRotateXAroundOrigin(controller.camera, rot_angle);
   }


### PR DESCRIPTION
- **Ur5 sandbox : refactor some things, set 2nd light**
- **core/DebugScene : pass scale variable to `addTriad()`**
- **Visualizer : make more buttons configurable (add to console commands print)**
- **multibody : remove plane (as a non-robot environment object)**
- **rename macro `CDW_ASSERT` to `CANDLEWICK_ASSERT` (for consistency**
- **imgui : sync submodule**
- **core/DebugScene : minor code change**
- **core/DebugScene.cpp : clean up entities for DebugMeshComponent**
- **core/DebugScene : remove private member function renderMeshComponents()**
- **minor updates**
- **bindings/python : extinguish 'multibody' sub namespace**
- **Fix the stubs mess (recursive stubs including for pure-Python files...)**
- **Update CHANGELOG**
- **core/`DebugScene` : add move ctor, explicitly delete move assignment op**
- **multibody : deprecate header `<candlewick/multibody/Components.h>`**
