### PR TITLE
multibody : allow reloading geometry models in `RobotScene` and `Visualizer`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,12 +30,12 @@ repos:
                 doc/doxygen-awesome.*
             )$
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: 'v0.12.3'
+    rev: 'v0.12.4'
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/BlankSpruce/gersemi
-    rev: 0.20.1
+    rev: 0.21.0
     hooks:
       - id: gersemi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - multibody/RobotScene : allow reloading models, decouple model loading from render pipeline creation
 - core/DepthAndShadowPass : add `ShadowMapPass::initialized()`
 - core | multibody : rework of debug subsystem API, allow reloading RobotDebugSystem
+- multibody/Visualizer : implement `loadViewerModel()`, allow it to actually reload models
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added tools for loading models from a given description struct `RobotSpec` (https://github.com/Simple-Robotics/candlewick/pull/37)
 - Added Candlewick visualizer runtime, to be used to (up)load Pinocchio models and submit states to be displayed asynchronously. (https://github.com/Simple-Robotics/candlewick/pull/37)
 - Embed Inter Medium font into the application (https://github.com/Simple-Robotics/candlewick/pull/37)
+- Add `RobotDebugSystem::reload()` function to switch out models
 
 ### Changed
 
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - core/Components : add `MeshMaterialComponent::hasTransparency()`
 - multibody/RobotScene : allow reloading models, decouple model loading from render pipeline creation
 - core/DepthAndShadowPass : add `ShadowMapPass::initialized()`
+- core | multibody : rework of debug subsystem API, allow reloading RobotDebugSystem
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CMake : sync jrl-cmakemodules to new release 1.0.0 (https://github.com/Simple-Robotics/candlewick/pull/37)
 - CMake : change option `BUILD_PYTHON_BINDINGS` to `BUILD_PYTHON_INTERFACE` (https://github.com/Simple-Robotics/candlewick/pull/37)
 - multibody/Visualizer : `stopRecording()` now returns a flag (https://github.com/Simple-Robotics/candlewick/pull/37)
+- core/Components : add `MeshMaterialComponent::hasTransparency()`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CMake : change option `BUILD_PYTHON_BINDINGS` to `BUILD_PYTHON_INTERFACE` (https://github.com/Simple-Robotics/candlewick/pull/37)
 - multibody/Visualizer : `stopRecording()` now returns a flag (https://github.com/Simple-Robotics/candlewick/pull/37)
 - core/Components : add `MeshMaterialComponent::hasTransparency()`
+- multibody/RobotScene : allow reloading models, decouple model loading from render pipeline creation
+- core/DepthAndShadowPass : add `ShadowMapPass::initialized()`
 
 ### Fixed
 

--- a/examples/Ur5WithSystems.cpp
+++ b/examples/Ur5WithSystems.cpp
@@ -325,8 +325,8 @@ int main(int argc, char **argv) {
   auto [triad_id, triad] = debug_scene.addTriad();
   auto [grid_id, grid] = debug_scene.addLineGrid(0xE0A236ff_rgbaf);
   pin::FrameIndex ee_frame_id = model.getFrameId("ee_link");
-  robot_debug.addFrameTriad(debug_scene, ee_frame_id);
-  robot_debug.addFrameVelocityArrow(debug_scene, ee_frame_id);
+  robot_debug.addFrameTriad(ee_frame_id);
+  robot_debug.addFrameVelocityArrow(ee_frame_id);
 
   DepthPass depthPass(renderer.device, plane_obj.mesh.layout(),
                       renderer.depth_texture,

--- a/src/candlewick/core/Components.cpp
+++ b/src/candlewick/core/Components.cpp
@@ -2,17 +2,19 @@
 #include <algorithm>
 
 namespace candlewick {
+bool MeshMaterialComponent::hasTransparency() const {
+  return std::ranges::any_of(
+      materials, [](auto &material) { return material.baseColor.w() < 1.0f; });
+}
+
 bool updateTransparencyClassification(entt::registry &reg, entt::entity entity,
                                       const MeshMaterialComponent &mmc) {
-  bool hasTransparency = std::ranges::any_of(mmc.materials, [](auto &material) {
-    return material.baseColor.w() < 1.0f;
-  });
-
-  if (hasTransparency) {
+  bool is_transparent = mmc.hasTransparency();
+  if (is_transparent) {
     reg.remove<Opaque>(entity);
   } else {
     reg.emplace_or_replace<Opaque>(entity);
   }
-  return hasTransparency;
+  return is_transparent;
 }
 } // namespace candlewick

--- a/src/candlewick/core/Components.h
+++ b/src/candlewick/core/Components.h
@@ -28,6 +28,8 @@ struct MeshMaterialComponent {
       : mesh(std::move(mesh)), materials(std::move(materials)) {
     assert(mesh.numViews() == materials.size());
   }
+
+  bool hasTransparency() const;
 };
 
 /// \brief Updates (adds or removes) the Opaque tag component for a given

--- a/src/candlewick/core/DebugScene.h
+++ b/src/candlewick/core/DebugScene.h
@@ -22,8 +22,12 @@ class DebugScene;
 /// Provides methods for updating debug entities.
 /// \sa DebugScene
 struct IDebugSubSystem {
-  virtual void update(DebugScene & /*scene*/) = 0;
+  virtual void update() = 0;
   virtual ~IDebugSubSystem() = default;
+
+protected:
+  DebugScene &m_scene;
+  explicit IDebugSubSystem(DebugScene &scene) : m_scene(scene) {}
 };
 
 /// \brief Component for simple mesh with colors.
@@ -69,7 +73,7 @@ public:
   /// \brief Add a subsystem (IDebugSubSystem) to the scene.
   template <std::derived_from<IDebugSubSystem> System, typename... Args>
   System &addSystem(Args &&...args) {
-    auto sys = std::make_unique<System>(std::forward<Args>(args)...);
+    auto sys = std::make_unique<System>(*this, std::forward<Args>(args)...);
     auto &p = m_subsystems.emplace_back(std::move(sys));
     return static_cast<System &>(*p);
   }
@@ -85,7 +89,7 @@ public:
 
   void update() {
     for (auto &system : m_subsystems) {
-      system->update(*this);
+      system->update();
     }
   }
 

--- a/src/candlewick/core/DepthAndShadowPass.h
+++ b/src/candlewick/core/DepthAndShadowPass.h
@@ -29,10 +29,16 @@
 #include "math_types.h"
 #include "LightUniforms.h"
 
-#include <SDL3/SDL_gpu.h>
 #include <span>
 
 namespace candlewick {
+
+/// \brief Intermediary argument type for shadow-casting or opaque objects. For
+/// use in depth or light pre-passes.
+using OpaqueCastable = std::tuple<const Mesh &, Mat4f>;
+
+/// \brief Maximum number of lights.
+static constexpr size_t kNumLights = 4;
 
 /// \ingroup depth_pass
 /// \brief Helper struct for depth or light pre-passes.
@@ -94,8 +100,6 @@ public:
   void release() noexcept;
   ~DepthPass() noexcept { this->release(); }
 };
-
-static constexpr size_t kNumLights = 4;
 
 /// \ingroup depth_pass
 struct ShadowPassConfig {

--- a/src/candlewick/core/DepthAndShadowPass.h
+++ b/src/candlewick/core/DepthAndShadowPass.h
@@ -156,6 +156,10 @@ public:
   ShadowMapPass(ShadowMapPass &&other) noexcept;
   ShadowMapPass &operator=(ShadowMapPass &&other) noexcept;
 
+  bool initialized() const {
+    return (pipeline != nullptr) && (sampler != nullptr);
+  }
+
   void render(CommandBuffer &cmdBuf, std::span<const OpaqueCastable> castables);
 
   void release() noexcept;

--- a/src/candlewick/core/MeshLayout.h
+++ b/src/candlewick/core/MeshLayout.h
@@ -18,6 +18,30 @@ inline bool operator==(const SDL_GPUVertexAttribute &lhs,
 #undef _c
 }
 
+inline std::strong_ordering
+operator<=>(const SDL_GPUVertexAttribute &lhs,
+            const SDL_GPUVertexAttribute &rhs) noexcept {
+  if (auto cmp = lhs.location <=> rhs.location; cmp != 0)
+    return cmp;
+  if (auto cmp = lhs.buffer_slot <=> rhs.buffer_slot; cmp != 0)
+    return cmp;
+  if (auto cmp = lhs.format <=> rhs.format; cmp != 0)
+    return cmp;
+  return lhs.offset <=> rhs.offset;
+}
+
+inline std::strong_ordering
+operator<=>(const SDL_GPUVertexBufferDescription &lhs,
+            const SDL_GPUVertexBufferDescription &rhs) noexcept {
+  if (auto cmp = lhs.slot <=> rhs.slot; cmp != 0)
+    return cmp;
+  if (auto cmp = lhs.pitch <=> rhs.pitch; cmp != 0)
+    return cmp;
+  if (auto cmp = lhs.input_rate <=> rhs.input_rate; cmp != 0)
+    return cmp;
+  return lhs.instance_step_rate <=> rhs.instance_step_rate;
+}
+
 namespace candlewick {
 
 constexpr Uint64 vertexElementSize(SDL_GPUVertexElementFormat format) {
@@ -157,25 +181,9 @@ public:
     return toVertexInputState();
   }
 
-  bool operator==(const MeshLayout &other) const noexcept {
-    if (numBuffers() != other.numBuffers() &&
-        numAttributes() != other.numAttributes())
-      return false;
+  std::strong_ordering operator<=>(const MeshLayout &other) const noexcept;
 
-    // for (Uint16 i = 0; i < numBuffers(); i++) {
-    //   if (m_bufferDescs[i] != other.m_bufferDescs[i])
-    //     return false;
-    // }
-    if (m_bufferDescs != other.m_bufferDescs)
-      return false;
-    // for (Uint16 i = 0; i < numAttributes(); i++) {
-    //   if (m_attrs[i] != other.m_attrs[i])
-    //     return false;
-    // }
-    if (m_attrs != other.m_attrs)
-      return false;
-    return true;
-  }
+  bool operator==(const MeshLayout &other) const noexcept = default;
 
   /// \brief Number of vertex buffers.
   Uint32 numBuffers() const { return Uint32(m_bufferDescs.size()); }
@@ -193,6 +201,17 @@ public:
 private:
   Uint32 m_totalVertexSize;
 };
+
+inline std::strong_ordering
+MeshLayout::operator<=>(const MeshLayout &other) const noexcept {
+  if (auto cmp = numBuffers() <=> other.numBuffers(); cmp != 0)
+    return cmp;
+  if (auto cmp = numAttributes() <=> other.numAttributes(); cmp != 0)
+    return cmp;
+  if (auto cmp = m_bufferDescs <=> other.m_bufferDescs; cmp != 0)
+    return cmp;
+  return m_attrs <=> other.m_attrs;
+}
 
 /// \brief Validation function. Checks if a MeshLayout produces invalid data for
 /// a Mesh.

--- a/src/candlewick/core/Shader.cpp
+++ b/src/candlewick/core/Shader.cpp
@@ -1,8 +1,6 @@
 #include "Shader.h"
 #include "Device.h"
 #include "errors.h"
-#include <SDL3/SDL_assert.h>
-#include <SDL3/SDL_log.h>
 
 #define JSON_NO_IO
 #define JSON_USE_IMPLICIT_CONVERSIONS 0
@@ -22,7 +20,6 @@ SDL_GPUShaderStage detect_shader_stage(const char *filename) {
   else if (SDL_strstr(filename, ".frag"))
     stage = SDL_GPU_SHADERSTAGE_FRAGMENT;
   else {
-    SDL_Log("Failed to detect Shader stage.");
     stage = SDL_GPUShaderStage(-1);
   }
   return stage;
@@ -43,9 +40,6 @@ ShaderCode loadShaderFile(const char *filename, const char *shader_ext) {
   char shader_path[256];
   SDL_snprintf(shader_path, sizeof(shader_path), "%s/%s.%s",
                g_shader_dir.c_str(), filename, shader_ext);
-#ifndef NDEBUG
-  SDL_Log("Loading shader file %s", shader_path);
-#endif
 
   size_t code_size;
   void *code = SDL_LoadFile(shader_path, &code_size);
@@ -58,6 +52,9 @@ ShaderCode loadShaderFile(const char *filename, const char *shader_ext) {
 Shader::Shader(const Device &device, const char *filename, const Config &config)
     : _shader(nullptr), _device(device) {
   _stage = detect_shader_stage(filename);
+  if (_stage < 0)
+    terminate_with_message("Failed to infer shader stage for filename {:s}",
+                           filename);
 
   SDL_GPUShaderFormat supported_formats = device.shaderFormats();
   SDL_GPUShaderFormat target_format = SDL_GPU_SHADERFORMAT_INVALID;

--- a/src/candlewick/core/math_types.h
+++ b/src/candlewick/core/math_types.h
@@ -170,10 +170,4 @@ namespace math {
   }
 } // namespace math
 
-class Mesh;
-
-/// \brief Intermediary argument type for shadow-casting or opaque objects. For
-/// use in depth or light pre-passes.
-using OpaqueCastable = std::tuple<const Mesh &, Mat4f>;
-
 } // namespace candlewick

--- a/src/candlewick/multibody/RobotDebug.h
+++ b/src/candlewick/multibody/RobotDebug.h
@@ -11,14 +11,14 @@ namespace candlewick::multibody {
 /// refer to an existing pinocchio::Data object at all times.
 struct RobotDebugSystem final : IDebugSubSystem {
 
-  RobotDebugSystem(const pin::Model &model, const pin::Data &data)
-      : IDebugSubSystem(), m_robotModel(&model), m_robotData(&data) {}
+  RobotDebugSystem(DebugScene &scene, const pin::Model &model,
+                   const pin::Data &data)
+      : IDebugSubSystem(scene), m_robotModel(&model), m_robotData(&data) {}
 
-  entt::entity addFrameTriad(DebugScene &scene, pin::FrameIndex frame_id,
+  entt::entity addFrameTriad(pin::FrameIndex frame_id,
                              const Float3 &scale = Float3::Constant(0.3333f));
 
-  entt::entity addFrameVelocityArrow(DebugScene &scene,
-                                     pin::FrameIndex frame_id,
+  entt::entity addFrameVelocityArrow(pin::FrameIndex frame_id,
                                      float scale = 0.5f);
 
   /// \brief Update the transform components for the debug visual entities,
@@ -26,7 +26,21 @@ struct RobotDebugSystem final : IDebugSubSystem {
   ///
   /// \warning We expect pinocchio::updateFramePlacements() or
   /// pinocchio::framesForwardKinematics() to be called first!
-  void update(DebugScene &scene);
+  void update() override;
+
+  void destroyEntities();
+
+  ~RobotDebugSystem() {
+    this->destroyEntities();
+    this->m_robotModel = nullptr;
+    this->m_robotData = nullptr;
+  }
+
+  void reload(const pin::Model &model, const pin::Data &data) {
+    this->destroyEntities();
+    this->m_robotModel = &model;
+    this->m_robotData = &data;
+  }
 
 private:
   pin::Model const *m_robotModel;

--- a/src/candlewick/multibody/RobotDebug.h
+++ b/src/candlewick/multibody/RobotDebug.h
@@ -12,7 +12,7 @@ namespace candlewick::multibody {
 struct RobotDebugSystem final : IDebugSubSystem {
 
   RobotDebugSystem(const pin::Model &model, const pin::Data &data)
-      : IDebugSubSystem(), m_robotModel(model), m_robotData(data) {}
+      : IDebugSubSystem(), m_robotModel(&model), m_robotData(&data) {}
 
   entt::entity addFrameTriad(DebugScene &scene, pin::FrameIndex frame_id,
                              const Float3 &scale = Float3::Constant(0.3333f));
@@ -29,8 +29,8 @@ struct RobotDebugSystem final : IDebugSubSystem {
   void update(DebugScene &scene);
 
 private:
-  const pin::Model &m_robotModel;
-  const pin::Data &m_robotData;
+  pin::Model const *m_robotModel;
+  pin::Data const *m_robotData;
 };
 
 } // namespace candlewick::multibody

--- a/src/candlewick/multibody/RobotScene.cpp
+++ b/src/candlewick/multibody/RobotScene.cpp
@@ -140,6 +140,8 @@ RobotScene::RobotScene(entt::registry &registry, const RenderContext &renderer,
                        const pin::GeometryData &geom_data, Config config)
     : RobotScene(registry, renderer) {
   m_config = config;
+
+  this->initGBuffer();
   this->loadModels(geom_model, geom_data);
 }
 
@@ -251,8 +253,6 @@ void RobotScene::loadModels(const pin::GeometryModel &geom_model,
   assert(!(m_initialized || hasInternalPointers()));
   m_geomModel = &geom_model;
   m_geomData = &geom_data;
-
-  this->initGBuffer();
 
   // initialize render target for GBuffer
   const bool enable_shadows = m_config.enable_shadows;

--- a/src/candlewick/multibody/RobotScene.h
+++ b/src/candlewick/multibody/RobotScene.h
@@ -18,6 +18,7 @@
 #include <entt/entity/fwd.hpp>
 #include <coal/fwd.hh>
 #include <pinocchio/multibody/fwd.hpp>
+#include <set>
 
 namespace candlewick {
 
@@ -141,6 +142,11 @@ namespace multibody {
       Texture accumTexture{NoInit};
       Texture revealTexture{NoInit};
       SDL_GPUSampler *sampler = nullptr; // composite pass
+
+      bool initialized() const {
+        return (sampler != nullptr) && normalMap && accumTexture &&
+               revealTexture;
+      }
     } gBuffer;
     ShadowMapPass shadowPass{NoInit};
 
@@ -212,6 +218,12 @@ namespace multibody {
     const Config &config() const { return m_config; }
     inline bool pbrHasPrepass() const { return m_config.triangle_has_prepass; }
     inline bool shadowsEnabled() const { return m_config.enable_shadows; }
+
+    /// \brief Ensure the render pipelines were properly created following the
+    /// provided requirements.
+    void ensurePipelinesExist(
+        const std::set<std::tuple<MeshLayout, PipelineType, bool>>
+            &required_pipelines);
 
     /// \brief Getter for the pinocchio GeometryModel object.
     const pin::GeometryModel &geomModel() const { return *m_geomModel; }

--- a/src/candlewick/multibody/RobotScene.h
+++ b/src/candlewick/multibody/RobotScene.h
@@ -4,17 +4,17 @@
 #pragma once
 
 #include "Multibody.h"
+
 #include "../core/Device.h"
 #include "../core/Scene.h"
 #include "../core/RenderContext.h"
 #include "../core/LightUniforms.h"
-#include "../core/Collision.h"
 #include "../core/DepthAndShadowPass.h"
 #include "../core/Texture.h"
 #include "../posteffects/SSAO.h"
 #include "../utils/MeshData.h"
-#include <magic_enum/magic_enum.hpp>
 
+#include <magic_enum/magic_enum.hpp>
 #include <entt/entity/fwd.hpp>
 #include <coal/fwd.hh>
 #include <pinocchio/multibody/fwd.hpp>
@@ -132,16 +132,6 @@ namespace multibody {
       ShadowPassConfig shadow_config;
     };
 
-    struct Pipelines {
-      struct {
-        SDL_GPUGraphicsPipeline *opaque = nullptr;
-        SDL_GPUGraphicsPipeline *transparent = nullptr;
-      } triangleMesh;
-      SDL_GPUGraphicsPipeline *heightfield = nullptr;
-      SDL_GPUGraphicsPipeline *pointcloud = nullptr;
-      SDL_GPUGraphicsPipeline *wboitComposite = nullptr;
-    } pipelines;
-
     std::array<DirectionalLight, kNumLights> directionalLight;
     ssao::SsaoPass ssaoPass{NoInit};
     struct GBuffer {
@@ -202,10 +192,10 @@ namespace multibody {
     /// (Pinocchio geometry objects).
     void clearRobotGeometries();
 
-    void createPipeline(const MeshLayout &layout,
-                        SDL_GPUTextureFormat render_target_format,
-                        SDL_GPUTextureFormat depth_stencil_format,
-                        PipelineType type, bool transparent);
+    void createRenderPipeline(const MeshLayout &layout,
+                              SDL_GPUTextureFormat render_target_format,
+                              SDL_GPUTextureFormat depth_stencil_format,
+                              PipelineType type, bool transparent);
 
     /// \warning Call updateTransforms() before rendering the objects with
     /// this function.
@@ -229,14 +219,9 @@ namespace multibody {
     /// \brief Getter for the pinocchio GeometryData object.
     const pin::GeometryData &geomData() const { return *m_geomData; }
 
-    const entt::registry &registry() const { return m_registry; }
-
     const Device &device() { return m_renderer.device; }
-
-    SDL_GPUGraphicsPipeline *getPipeline(PipelineType type,
-                                         bool transparent = false) {
-      return *routePipeline(type, transparent);
-    }
+    entt::registry &registry() { return m_registry; }
+    const entt::registry &registry() const { return m_registry; }
 
   private:
     entt::registry &m_registry;
@@ -246,17 +231,24 @@ namespace multibody {
     const pin::GeometryData *m_geomData;
     std::vector<OpaqueCastable> m_castables;
     bool m_initialized;
+    struct {
+      SDL_GPUGraphicsPipeline *triangleMeshOpaque = nullptr;
+      SDL_GPUGraphicsPipeline *triangleMeshTransparent = nullptr;
+      SDL_GPUGraphicsPipeline *heightfield = nullptr;
+      SDL_GPUGraphicsPipeline *pointcloud = nullptr;
+      SDL_GPUGraphicsPipeline *wboitComposite = nullptr;
+    } m_pipelines;
 
-    SDL_GPUGraphicsPipeline **routePipeline(PipelineType type,
-                                            bool transparent) {
+    SDL_GPUGraphicsPipeline *&routePipeline(PipelineType type,
+                                            bool transparent = false) {
       switch (type) {
       case PIPELINE_TRIANGLEMESH:
-        return transparent ? &pipelines.triangleMesh.transparent
-                           : &pipelines.triangleMesh.opaque;
+        return transparent ? m_pipelines.triangleMeshTransparent
+                           : m_pipelines.triangleMeshOpaque;
       case PIPELINE_HEIGHTFIELD:
-        return &pipelines.heightfield;
+        return m_pipelines.heightfield;
       case PIPELINE_POINTCLOUD:
-        return &pipelines.pointcloud;
+        return m_pipelines.pointcloud;
       }
     }
   };

--- a/src/candlewick/multibody/Visualizer.cpp
+++ b/src/candlewick/multibody/Visualizer.cpp
@@ -80,11 +80,6 @@ void Visualizer::initialize() {
   rconfig.enable_shadows = true;
   rconfig.enable_normal_target = true;
   robotScene.setConfig(rconfig);
-  robotScene.loadModels(visualModel(), visualData());
-
-  m_robotDebug = &debugScene.addSystem<RobotDebugSystem>(this->model(), data());
-  std::tie(m_triad, std::ignore) = debugScene.addTriad();
-  std::tie(m_grid, std::ignore) = debugScene.addLineGrid();
 
   robotScene.directionalLight = {
       DirectionalLight{
@@ -102,6 +97,7 @@ void Visualizer::initialize() {
   worldSceneBounds.update({-1., -1., 0.}, {+1., +1., 1.});
 
   this->resetCamera();
+  this->loadViewerModel();
 
   SDL_Log("┌───────Controls────────");
   SDL_Log("│ Toggle GUI:      [%s]", "H");
@@ -127,7 +123,18 @@ void Visualizer::resetCamera() {
       perspectiveFromFov(DEFAULT_FOV, aspectRatio, 0.01f, 100.f);
 }
 
-void Visualizer::loadViewerModel() {}
+void Visualizer::loadViewerModel() {
+  robotScene.loadModels(visualModel(), visualData());
+
+  if (m_robotDebug) {
+    m_robotDebug->reload(this->model(), this->data());
+  } else {
+    m_robotDebug =
+        &debugScene.addSystem<RobotDebugSystem>(this->model(), this->data());
+    std::tie(m_triad, std::ignore) = debugScene.addTriad();
+    std::tie(m_grid, std::ignore) = debugScene.addLineGrid();
+  }
+}
 
 void Visualizer::setCameraTarget(const Eigen::Ref<const Vector3> &target) {
   controller.lookAt1(target.cast<float>());

--- a/src/candlewick/multibody/Visualizer.cpp
+++ b/src/candlewick/multibody/Visualizer.cpp
@@ -245,17 +245,14 @@ bool Visualizer::stopRecording() {
 
 void Visualizer::addFrameViz(pin::FrameIndex id, bool show_velocity) {
   assert(m_robotDebug);
-  m_debug_frame_pos.push_back(m_robotDebug->addFrameTriad(debugScene, id));
+  m_robotDebug->addFrameTriad(id);
   if (show_velocity)
-    m_debug_frame_vel.push_back(
-        m_robotDebug->addFrameVelocityArrow(debugScene, id));
+    m_robotDebug->addFrameVelocityArrow(id);
 }
 
 void Visualizer::removeFramesViz() {
-  registry.destroy(m_debug_frame_pos.begin(), m_debug_frame_pos.end());
-  registry.destroy(m_debug_frame_vel.begin(), m_debug_frame_vel.end());
-  m_debug_frame_pos.clear();
-  m_debug_frame_vel.clear();
+  assert(m_robotDebug);
+  m_robotDebug->destroyEntities();
 }
 
 } // namespace candlewick::multibody

--- a/src/candlewick/multibody/Visualizer.h
+++ b/src/candlewick/multibody/Visualizer.h
@@ -57,8 +57,6 @@ class Visualizer final : public BaseVisualizer {
   bool m_shouldExit = false;
   entt::entity m_grid, m_triad;
   RobotDebugSystem *m_robotDebug = nullptr;
-  std::vector<entt::entity> m_debug_frame_pos;
-  std::vector<entt::entity> m_debug_frame_vel;
 
   void initialize();
 

--- a/src/candlewick/posteffects/ScreenSpaceShadows.h
+++ b/src/candlewick/posteffects/ScreenSpaceShadows.h
@@ -3,9 +3,9 @@
 #include "../core/Core.h"
 #include "../core/Tags.h"
 #include "../core/LightUniforms.h"
+#include "../core/DepthAndShadowPass.h"
 
 #include <SDL3/SDL_gpu.h>
-#include <span>
 
 namespace candlewick {
 namespace effects {

--- a/src/candlewick/utils/StridedView.h
+++ b/src/candlewick/utils/StridedView.h
@@ -57,7 +57,7 @@ public:
       return tmp;
     }
 
-    bool operator<=>(const iterator &) const = default;
+    auto operator<=>(const iterator &) const noexcept = default;
   };
   static_assert(std::forward_iterator<iterator>);
 

--- a/tests/TestMeshData.cpp
+++ b/tests/TestMeshData.cpp
@@ -40,7 +40,7 @@ bool operator==(const CustomVertex &lhs, const CustomVertex &rhs) {
 
 GTEST_TEST(TestErasedBlob, default_vertex) {
   auto layout = meshLayoutFor<DefaultVertex>();
-  EXPECT_TRUE(layout == layout);
+  EXPECT_EQ(layout, layout);
   std::vector<DefaultVertex> vertexData;
   const Uint64 size = 10;
   for (Uint64 i = 0; i < size; i++) {
@@ -74,8 +74,7 @@ GTEST_TEST(TestErasedBlob, default_vertex) {
 
 GTEST_TEST(TestErasedBlob, custom_vertex) {
   auto layout = meshLayoutFor<CustomVertex>();
-  EXPECT_TRUE(layout == layout);
-  EXPECT_TRUE(layout != meshLayoutFor<DefaultVertex>());
+  EXPECT_NE(layout, meshLayoutFor<DefaultVertex>());
   EXPECT_EQ(sizeof(CustomVertex), layout.vertexSize());
 
   std::vector<CustomVertex> vertexData;


### PR DESCRIPTION
- **multibody/RobotScene : simplify pipeline routing**
- **multibody/RobotScene.cpp : move GBuffer initialization to ctor (not loadModels())**
- **core/Components : add `MeshMaterialComponent::hasTransparency()`**
- **multibody/RobotScene.cpp : properly decouple pipeline creation from the GeometryModel loading pass**
- **pre-commit : autoupdate**
- **utils/StridedView.h : fix return value of spaceship operator**
- **core/MeshLayout : implement spaceship operator for `MeshLayout` class**
- **multibody/RobotScene : allow reloading models, decouple model loading from render pipeline creation**
- **multibody/RobotDebug : store geom model and data by pointer**
- **core | multibody : rework of debug subsystem API, allow reloading RobotDebugSystem**
- **multibody/Visualizer : implement `loadViewerModel()`, allow it to actually reload models**
- **core/Shader.cpp : remove logging, add error throw when stage undetected**
